### PR TITLE
Add ARIA state handling for mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <span>Гірські котеджі</span>
       </div>
       <nav>
-        <button class="hamburger" aria-label="Відкрити меню" id="menuBtn">☰</button>
+        <button class="hamburger" aria-label="Відкрити меню" id="menuBtn" aria-expanded="false">☰</button>
         <div class="menu" id="menu">
           <a href="#about" class="active">Про нас</a>
           <a href="#cottages">Котеджі</a>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,12 @@ document.addEventListener('DOMContentLoaded', () => {
 // Мобільне меню
 const menuBtn = document.getElementById('menuBtn');
 const menu = document.getElementById('menu');
-menuBtn?.addEventListener('click', () => menu.classList.toggle('open'));
+menuBtn?.addEventListener('click', () => {
+  if (!menu || !menuBtn) return;
+  menu.classList.toggle('open');
+  const newState = menu.classList.contains('open');
+  menuBtn.setAttribute('aria-expanded', String(newState));
+});
 
 // Плавний скрол до секцій
 document.querySelectorAll('a[href^="#"]').forEach(a => {


### PR DESCRIPTION
## Summary
- Track mobile menu open state and update `aria-expanded`
- Initialize menu button with `aria-expanded="false"`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b50155e70832cb7accd82eae884e3