### PR TITLE
Add full photo galleries for cottages

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,18 @@
         <div class="grid">
           <!-- Card 1 -->
           <article class="card">
-            <img src="images/cottage1/cottage1-1.jpg" alt="Котедж Дерев'яний з каміном" loading="lazy" />
+            <div class="card-gallery">
+              <button class="prev" aria-label="Попереднє фото">‹</button>
+              <button class="next" aria-label="Наступне фото">›</button>
+              <img src="images/cottage1/cottage1-1.jpg" alt="Котедж #1 фото 1" loading="lazy" class="active" />
+              <img src="images/cottage1/cottage1-2.jpg" alt="Котедж #1 фото 2" loading="lazy" />
+              <img src="images/cottage1/cottage1-3.jpg" alt="Котедж #1 фото 3" loading="lazy" />
+              <img src="images/cottage1/cottage1-4.jpg" alt="Котедж #1 фото 4" loading="lazy" />
+              <img src="images/cottage1/cottage1-5.jpg" alt="Котедж #1 фото 5" loading="lazy" />
+              <img src="images/cottage1/cottage1-6.jpg" alt="Котедж #1 фото 6" loading="lazy" />
+              <img src="images/cottage1/cottage1-7.jpg" alt="Котедж #1 фото 7" loading="lazy" />
+              <img src="images/cottage1/cottage1-8.jpg" alt="Котедж #1 фото 8" loading="lazy" />
+            </div>
             <div class="card-body">
               <div class="badge">до 6 гостей</div>
               <h3>Котедж #1</h3>
@@ -90,7 +101,18 @@
           </article>
           <!-- Card 2 -->
           <article class="card">
-            <img src="images/cottage2/cottage2-1.jpg" alt="Котедж #2 у горах" loading="lazy" />
+            <div class="card-gallery">
+              <button class="prev" aria-label="Попереднє фото">‹</button>
+              <button class="next" aria-label="Наступне фото">›</button>
+              <img src="images/cottage2/cottage2-1.jpg" alt="Котедж #2 фото 1" loading="lazy" class="active" />
+              <img src="images/cottage2/cottage2-2.jpg" alt="Котедж #2 фото 2" loading="lazy" />
+              <img src="images/cottage2/cottage2-3.jpg" alt="Котедж #2 фото 3" loading="lazy" />
+              <img src="images/cottage2/cottage2-4.jpg" alt="Котедж #2 фото 4" loading="lazy" />
+              <img src="images/cottage2/cottage2-5.jpg" alt="Котедж #2 фото 5" loading="lazy" />
+              <img src="images/cottage2/cottage2-6.jpg" alt="Котедж #2 фото 6" loading="lazy" />
+              <img src="images/cottage2/cottage2-7.jpg" alt="Котедж #2 фото 7" loading="lazy" />
+              <img src="images/cottage2/cottage2-8.jpg" alt="Котедж #2 фото 8" loading="lazy" />
+            </div>
             <div class="card-body">
               <div class="badge">до 4 гостей</div>
               <h3>Котедж #2</h3>
@@ -124,7 +146,9 @@
       </div>
       <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Перегляд фото">
         <button class="close" id="lightboxClose" aria-label="Закрити">Закрити ✕</button>
+        <button class="prev" id="lightboxPrev" aria-label="Попереднє фото">‹</button>
         <img id="lightboxImg" alt="Збільшене зображення" />
+        <button class="next" id="lightboxNext" aria-label="Наступне фото">›</button>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -34,6 +34,11 @@ const gallery = document.getElementById('galleryGrid');
 const lightbox = document.getElementById('lightbox');
 const lightboxImg = document.getElementById('lightboxImg');
 const lightboxClose = document.getElementById('lightboxClose');
+const lightboxPrev = document.getElementById('lightboxPrev');
+const lightboxNext = document.getElementById('lightboxNext');
+
+let lbImages = [];
+let lbIndex = 0;
 
 function openLightbox(src, alt){
   if (!lightbox || !lightboxImg) return;
@@ -44,15 +49,54 @@ function closeLightbox(){
   if (!lightbox || !lightboxImg) return;
   lightbox.classList.remove('open');
   lightboxImg.src = '';
+  lbImages = [];
 }
+
+function openGallery(images, start=0){
+  lbImages = images;
+  lbIndex = start;
+  openLightbox(lbImages[lbIndex].src, lbImages[lbIndex].alt);
+  const showControls = lbImages.length > 1;
+  if(lightboxPrev && lightboxNext){
+    lightboxPrev.style.display = showControls ? 'block' : 'none';
+    lightboxNext.style.display = showControls ? 'block' : 'none';
+  }
+}
+function showNext(step){
+  if(!lbImages.length) return;
+  lbIndex = (lbIndex + step + lbImages.length) % lbImages.length;
+  openLightbox(lbImages[lbIndex].src, lbImages[lbIndex].alt);
+}
+
 gallery?.addEventListener('click', (e) => {
   const t = e.target;
   if(t && t.tagName === 'IMG'){
-    openLightbox(t.src, t.alt);
+    openGallery([{src: t.src, alt: t.alt}], 0);
   }
 });
+lightboxPrev?.addEventListener('click', (e) => { e.stopPropagation(); showNext(-1); });
+lightboxNext?.addEventListener('click', (e) => { e.stopPropagation(); showNext(1); });
 lightboxClose?.addEventListener('click', closeLightbox);
 lightbox?.addEventListener('click', (e) => { if(e.target === lightbox) closeLightbox(); });
-document.addEventListener('keydown', (e) => { if(e.key === 'Escape') closeLightbox(); });
+document.addEventListener('keydown', (e) => {
+  if(!lightbox?.classList.contains('open')) return;
+  if(e.key === 'Escape') closeLightbox();
+  if(e.key === 'ArrowRight') showNext(1);
+  if(e.key === 'ArrowLeft') showNext(-1);
+});
+
+// Слайдер для карток котеджів
+document.querySelectorAll('.card-gallery').forEach(gal => {
+  const imgs = gal.querySelectorAll('img');
+  let idx = 0;
+  const show = (i) => imgs.forEach((img,j)=>img.classList.toggle('active', j===i));
+  gal.querySelector('.prev')?.addEventListener('click', (e)=>{ e.stopPropagation(); idx=(idx-1+imgs.length)%imgs.length; show(idx); });
+  gal.querySelector('.next')?.addEventListener('click', (e)=>{ e.stopPropagation(); idx=(idx+1)%imgs.length; show(idx); });
+  gal.addEventListener('click', () => {
+    const arr = Array.from(imgs).map(img => ({src: img.src, alt: img.alt}));
+    openGallery(arr, idx);
+  });
+  show(0);
+});
 
 // Хелпер для Viber/Telegram (за потреби)

--- a/style.css
+++ b/style.css
@@ -50,9 +50,14 @@ section { padding: 64px 0; }
 .muted { color: var(--muted); }
 
 /* Cottages grid */
-.grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 20px; }
-.card { grid-column: span 4; background: var(--card); border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
-.card img { width: 100%; height: 220px; object-fit: cover; }
+.grid { display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+.card { background: var(--card); border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
+.card-gallery { position: relative; }
+.card-gallery img { width: 100%; height: 220px; object-fit: cover; display: none; }
+.card-gallery img.active { display: block; }
+.card-gallery button { position: absolute; top: 50%; transform: translateY(-50%); background: rgba(255,255,255,.8); border: none; width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-weight: 700; }
+.card-gallery button.prev { left: 8px; }
+.card-gallery button.next { right: 8px; }
 .card-body { padding: 16px; display: grid; gap: 10px; }
 .badge { display: inline-block; padding: 6px 10px; border-radius: 999px; background: #f0f6f2; color: var(--brand); font-weight: 700; font-size: 12px; }
 .features { display: flex; flex-wrap: wrap; gap: 10px; color: var(--muted); font-size: 14px; }
@@ -68,6 +73,10 @@ section { padding: 64px 0; }
 .lightbox.open { display: flex; }
 .lightbox img { max-width: 96vw; max-height: 85vh; border-radius: 12px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
 .lightbox .close { position: absolute; top: 20px; right: 20px; background: white; border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; }
+.lightbox .prev,
+.lightbox .next { position: absolute; top: 50%; transform: translateY(-50%); background: white; border: none; width: 44px; height: 44px; border-radius: 50%; cursor: pointer; font-size: 24px; font-weight: 700; display: none; }
+.lightbox .prev { left: 20px; }
+.lightbox .next { right: 20px; }
 
 /* Contacts */
 .contacts { display: grid; grid-template-columns: 1.1fr .9fr; gap: 20px; }
@@ -86,12 +95,10 @@ footer { padding: 40px 0; color: var(--muted); text-align: center; }
 @media (max-width: 960px){
   .hero-wrap { grid-template-columns: 1fr; }
   .contacts { grid-template-columns: 1fr; }
-  .card { grid-column: span 6; }
 }
 @media (max-width: 640px){
   .menu { display: none; position: absolute; top: 64px; left: 0; right: 0; background: white; border-bottom: 1px solid #e7efe9; padding: 10px 20px 16px; flex-direction: column; gap: 12px; }
   .menu.open { display: flex; }
   .hamburger { display: inline-flex; }
-  .card { grid-column: span 12; }
   section { padding: 48px 0; }
 }


### PR DESCRIPTION
## Summary
- Show all images for each cottage with in-card slider and lightbox navigation
- Expand cottage grid to use full width on large screens
- Add keyboard and button controls for browsing lightbox images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f0415fd9c832ca288efcaca2280ed