### PR TITLE
feat: shift color theme toward red

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <path fill="#2e3d33" d="M32 6 4 24v28h56V24z"/>
-  <path fill="#9bcb93" d="M12 48V27l20-13 20 13v21z"/>
+  <path fill="#8b2c34" d="M32 6 4 24v28h56V24z"/>
+  <path fill="#d86e6e" d="M12 48V27l20-13 20 13v21z"/>
 </svg>

--- a/style.css
+++ b/style.css
@@ -3,9 +3,9 @@
   --card: #ffffff;
   --text: #2b2a27;
   --muted: #6b6459;
-  --brand: #386641;
-  --brand-2: #8b5e34;
-  --ring: rgba(56, 102, 65, 0.25);
+  --brand: #d64045;
+  --brand-2: #8b2c34;
+  --ring: rgba(214, 64, 69, 0.25);
   --shadow: 0 10px 25px rgba(0,0,0,.08);
   --radius: 16px;
   --container: 1200px;
@@ -39,7 +39,7 @@ header {
 .hero h1 { font-size: clamp(28px, 4vw, 48px); line-height: 1.05; margin: 0 0 12px; }
 .hero p { color: var(--muted); font-size: clamp(16px, 1.6vw, 18px); margin: 0 0 22px; }
 .cta { display: inline-flex; gap: 12px; align-items: center; background: var(--brand); color: white; padding: 14px 18px; border-radius: 12px; font-weight: 700; border: none; cursor: pointer; box-shadow: var(--shadow); }
-.cta.secondary { background: #f3ece7; color: var(--brand-2); }
+.cta.secondary { background: #fdeaea; color: var(--brand-2); }
 .hero-card { position: relative; background: var(--card); border-radius: 24px; overflow: hidden; box-shadow: var(--shadow); }
 .hero-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
@@ -59,7 +59,7 @@ section { padding: 64px 0; }
 .card-gallery button.prev { left: 8px; }
 .card-gallery button.next { right: 8px; }
 .card-body { padding: 16px; display: grid; gap: 10px; }
-.badge { display: inline-block; padding: 6px 10px; border-radius: 999px; background: #f3ece7; color: var(--brand-2); font-weight: 700; font-size: 12px; }
+.badge { display: inline-block; padding: 6px 10px; border-radius: 999px; background: #fdeaea; color: var(--brand-2); font-weight: 700; font-size: 12px; }
 .features { display: flex; flex-wrap: wrap; gap: 10px; color: var(--muted); font-size: 14px; }
 .price { font-size: 18px; font-weight: 800; }
 .actions { display: flex; gap: 10px; margin-top: 4px; }


### PR DESCRIPTION
## Summary
- switch brand colors from green to red and adjust accent backgrounds
- update favicon to match new red palette

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f709d7078832c996013c7f755e3c2