### PR TITLE
Fix cottage card image sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -62,14 +62,21 @@ section { padding: 64px 0; }
 /* Cottages grid */
 .grid { display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
 .card { background: var(--card); border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
-.card-gallery { position: relative; }
+.card-gallery {
+  position: relative;
+  aspect-ratio: 3/2;
+  overflow: hidden;
+}
 .card-gallery img {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
   display: none;
 }
 .card-gallery img.active { display: block; }
-.card-gallery button { position: absolute; top: 50%; transform: translateY(-50%); background: rgba(255,255,255,.8); border: none; width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-weight: 700; }
+.card-gallery button { position: absolute; top: 50%; transform: translateY(-50%); background: rgba(255,255,255,.8); border: none; width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-weight: 700; z-index: 1; }
 .card-gallery button.prev { left: 8px; }
 .card-gallery button.next { right: 8px; }
 .card-body { padding: 16px; display: grid; gap: 10px; }


### PR DESCRIPTION
## Summary
- enforce consistent preview size for cottage card images using `aspect-ratio`
- crop card images with `object-fit: cover` and absolute positioning to prevent card height changes
- keep gallery navigation buttons visible with a higher z-index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a32eb281bc832c8f3e0f766d40335b