### PR TITLE
Fix hero padding and section subtitles layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ header {
 
 /* Hero */
 .hero { position: relative; overflow: hidden; border-bottom-left-radius: 32px; border-bottom-right-radius: 32px; }
-.hero-wrap { display: grid; grid-template-columns: 1.1fr .9fr; gap: 36px; align-items: center; padding: 56px 0; }
+.hero-wrap { display: grid; grid-template-columns: 1.1fr .9fr; gap: 36px; align-items: center; padding: 56px 20px; }
 .hero h1 { font-size: clamp(28px, 4vw, 48px); line-height: 1.05; margin: 0 0 12px; }
 .hero p { color: var(--muted); font-size: clamp(16px, 1.6vw, 18px); margin: 0 0 22px; }
 .cta { display: inline-flex; gap: 12px; align-items: center; background: var(--brand); color: white; padding: 14px 18px; border-radius: 12px; font-weight: 700; border: none; cursor: pointer; box-shadow: var(--shadow); }
@@ -55,8 +55,9 @@ header {
 
 /* Sections */
 section { padding: 64px 0; }
-.section-head { display: flex; align-items: end; justify-content: space-between; gap: 16px; margin-bottom: 26px; }
+.section-head { display: grid; gap: 4px; margin-bottom: 26px; }
 .section-head h2 { font-size: clamp(22px, 3vw, 36px); margin: 0; }
+.section-head p { margin: 0; font-weight: 500; font-style: italic; }
 .muted { color: var(--muted); }
 
 /* Cottages grid */


### PR DESCRIPTION
## Summary
- add horizontal padding to hero section for consistent mobile spacing
- place section subtitles below their titles with tighter spacing and a distinctive italic style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33984c108832ca01ec8872e0e9fab