### PR TITLE
feat: add infinite review carousel with arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,11 @@
           <p class="muted">Досвід тих, хто вже відпочивав</p>
         </div>
         <div class="review-summary" id="reviewSummary"></div>
-        <div class="review-grid" id="reviewsList"></div>
+        <div class="review-carousel">
+          <button class="review-nav prev" id="reviewsPrev" aria-label="Попередній відгук">‹</button>
+          <div class="review-grid" id="reviewsList"></div>
+          <button class="review-nav next" id="reviewsNext" aria-label="Наступний відгук">›</button>
+        </div>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -158,41 +158,29 @@ function renderReviews(){
     list.appendChild(first);
     list.insertBefore(last, list.firstElementChild);
 
-    const cardWidth = list.firstElementChild.offsetWidth;
+    const gap = parseInt(getComputedStyle(list).columnGap || getComputedStyle(list).gap) || 0;
+    const cardWidth = list.firstElementChild.offsetWidth + gap;
     list.scrollLeft = cardWidth;
 
     list.addEventListener('scroll', () => {
       if (list.scrollLeft <= 0) {
+        list.style.scrollBehavior = 'auto';
         list.scrollLeft = list.scrollWidth - cardWidth * 2;
+        list.style.scrollBehavior = 'smooth';
       } else if (list.scrollLeft >= list.scrollWidth - list.clientWidth) {
+        list.style.scrollBehavior = 'auto';
         list.scrollLeft = cardWidth;
+        list.style.scrollBehavior = 'smooth';
       }
     });
 
-    list.addEventListener('wheel', (e) => {
-      e.preventDefault();
-      list.scrollLeft += e.deltaY;
-    });
-
-    let isDown = false;
-    let startX = 0;
-    let scrollStart = 0;
-    list.addEventListener('mousedown', (e) => {
-      isDown = true;
-      startX = e.pageX;
-      scrollStart = list.scrollLeft;
-      list.classList.add('dragging');
-    });
-    ['mouseleave','mouseup'].forEach(evt => list.addEventListener(evt, () => {
-      isDown = false;
-      list.classList.remove('dragging');
-    }));
-    list.addEventListener('mousemove', (e) => {
-      if(!isDown) return;
-      e.preventDefault();
-      const walk = e.pageX - startX;
-      list.scrollLeft = scrollStart - walk;
-    });
+    const prev = document.getElementById('reviewsPrev');
+    const next = document.getElementById('reviewsNext');
+    const scrollByCard = (dir) => {
+      list.scrollBy({ left: cardWidth * dir, behavior: 'smooth' });
+    };
+    prev.addEventListener('click', () => scrollByCard(-1));
+    next.addEventListener('click', () => scrollByCard(1));
   }
 
   const stats = {};

--- a/style.css
+++ b/style.css
@@ -116,8 +116,12 @@ section { padding: 64px 0; }
 .review-summary .source-icon,
 .review-card .source-icon { width: 24px; height: 24px; border-radius: 50%; }
 .review-summary .overall { display: flex; align-items: center; gap: 8px; justify-content: center; font-weight: 700; }
-.review-grid { display: flex; gap: 20px; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; scroll-behavior: smooth; cursor: grab; }
-.review-grid.dragging { cursor: grabbing; user-select: none; }
+.review-carousel { position: relative; }
+.review-grid { display: flex; gap: 20px; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; scroll-behavior: smooth; }
+.review-nav { position: absolute; top: 50%; transform: translateY(-50%); background: var(--card); border: none; width: 44px; height: 44px; border-radius: 50%; box-shadow: var(--shadow); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 24px; font-weight: 700; }
+.review-nav.prev { left: -22px; }
+.review-nav.next { right: -22px; }
+@media (hover: none) and (pointer: coarse) { .review-nav { display: none; } }
 .review-grid::-webkit-scrollbar { display: none; }
 .review-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; display: grid; gap: 10px; flex: 0 0 260px; scroll-snap-align: start; }
 .review-card .review-header { display: flex; align-items: center; gap: 10px; }


### PR DESCRIPTION
## Summary
- replace mouse wheel review scrolling with arrow buttons
- enable seamless looping of review cards
- hide arrow controls on touch devices while keeping swipe scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a435de552c832cb940805c7e1fe07c