### PR TITLE
Fix infinite review slider when scrolling right

### DIFF
--- a/script.js
+++ b/script.js
@@ -167,13 +167,14 @@ function renderReviews(){
 
     const total = cards.length;
     list.scrollLeft = cardWidth * visible;
+    const maxScroll = list.scrollWidth - list.clientWidth;
 
     list.addEventListener('scroll', () => {
       if (list.scrollLeft <= 0) {
         list.style.scrollBehavior = 'auto';
         list.scrollLeft = cardWidth * total;
         list.style.scrollBehavior = 'smooth';
-      } else if (list.scrollLeft >= cardWidth * (total + visible)) {
+      } else if (list.scrollLeft >= maxScroll) {
         list.style.scrollBehavior = 'auto';
         list.scrollLeft = cardWidth * visible;
         list.style.scrollBehavior = 'smooth';


### PR DESCRIPTION
## Summary
- compute max scroll for review carousel using scrollWidth - clientWidth to prevent sticking when scrolling right

## Testing
- `node --check script.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68a43e4d8e00832ca3907572084ac7f6