### PR TITLE
Fix infinite review slider when scrolling right

### DIFF
--- a/script.js
+++ b/script.js
@@ -167,15 +167,17 @@ function renderReviews(){
 
     const total = cards.length;
     list.scrollLeft = cardWidth * visible;
+    const getMaxScroll = () => list.scrollWidth - list.clientWidth;
 
     list.addEventListener('scroll', () => {
+      const maxScroll = getMaxScroll();
       if (list.scrollLeft <= 0) {
         list.style.scrollBehavior = 'auto';
-        list.scrollLeft = cardWidth * total;
+        list.scrollLeft += cardWidth * total;
         list.style.scrollBehavior = 'smooth';
-      } else if (list.scrollLeft >= cardWidth * (total + visible)) {
+      } else if (list.scrollLeft >= maxScroll) {
         list.style.scrollBehavior = 'auto';
-        list.scrollLeft = cardWidth * visible;
+        list.scrollLeft -= cardWidth * total;
         list.style.scrollBehavior = 'smooth';
       }
     });
@@ -183,6 +185,16 @@ function renderReviews(){
     const prev = document.getElementById('reviewsPrev');
     const next = document.getElementById('reviewsNext');
     const scrollByCard = (dir) => {
+      const maxScroll = getMaxScroll();
+      if (dir > 0 && list.scrollLeft + cardWidth > maxScroll) {
+        list.style.scrollBehavior = 'auto';
+        list.scrollLeft -= cardWidth * total;
+        list.style.scrollBehavior = 'smooth';
+      } else if (dir < 0 && list.scrollLeft - cardWidth < 0) {
+        list.style.scrollBehavior = 'auto';
+        list.scrollLeft += cardWidth * total;
+        list.style.scrollBehavior = 'smooth';
+      }
       list.scrollBy({ left: cardWidth * dir, behavior: 'smooth' });
     };
     prev.addEventListener('click', () => scrollByCard(-1));


### PR DESCRIPTION
## Summary
- recompute max scroll on each move and wrap by shifting scroll position
- reset before arrow-based navigation to avoid jumps

## Testing
- `node --check script.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68a43e4d8e00832ca3907572084ac7f6