### PR TITLE
Enable swiping and zoom in gallery lightbox

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,16 +40,34 @@ const lightboxNext = document.getElementById('lightboxNext');
 let lbImages = [];
 let lbIndex = 0;
 
+let zoom = 1;
+let offsetX = 0, offsetY = 0;
+let dragStartX = 0, dragStartY = 0;
+let isDragging = false;
+let pinchDist = 0;
+let pinchZoom = 1;
+
+function updateZoom(){
+  if(!lightboxImg) return;
+  lightboxImg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${zoom})`;
+  lightboxImg.style.cursor = zoom > 1 ? 'grab' : 'auto';
+}
+function resetZoom(){
+  zoom = 1; offsetX = 0; offsetY = 0; updateZoom();
+}
+
 function openLightbox(src, alt){
   if (!lightbox || !lightboxImg) return;
   lightboxImg.src = src; lightboxImg.alt = alt || 'Зображення';
   lightbox.classList.add('open');
+  resetZoom();
 }
 function closeLightbox(){
   if (!lightbox || !lightboxImg) return;
   lightbox.classList.remove('open');
   lightboxImg.src = '';
   lbImages = [];
+  resetZoom();
 }
 
 function openGallery(images, start=0){
@@ -71,7 +89,10 @@ function showNext(step){
 gallery?.addEventListener('click', (e) => {
   const t = e.target;
   if(t && t.tagName === 'IMG'){
-    openGallery([{src: t.src, alt: t.alt}], 0);
+    const imgs = Array.from(gallery.querySelectorAll('img'));
+    const arr = imgs.map(img => ({src: img.src, alt: img.alt}));
+    const idx = imgs.indexOf(t);
+    openGallery(arr, idx);
   }
 });
 lightboxPrev?.addEventListener('click', (e) => { e.stopPropagation(); showNext(-1); });
@@ -84,6 +105,64 @@ document.addEventListener('keydown', (e) => {
   if(e.key === 'ArrowRight') showNext(1);
   if(e.key === 'ArrowLeft') showNext(-1);
 });
+
+// Zoom & swipe controls for lightbox image
+lightboxImg?.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const factor = e.deltaY < 0 ? 1.1 : 0.9;
+  zoom = Math.min(Math.max(zoom * factor, 1), 5);
+  updateZoom();
+});
+
+lightboxImg?.addEventListener('pointerdown', (e) => {
+  if(e.pointerType === 'mouse' && e.button !== 0) return;
+  dragStartX = e.clientX;
+  dragStartY = e.clientY;
+  isDragging = true;
+  lightboxImg.setPointerCapture(e.pointerId);
+});
+lightboxImg?.addEventListener('pointermove', (e) => {
+  if(!isDragging) return;
+  if(zoom > 1){
+    offsetX += e.clientX - dragStartX;
+    offsetY += e.clientY - dragStartY;
+    dragStartX = e.clientX;
+    dragStartY = e.clientY;
+    updateZoom();
+  }
+});
+lightboxImg?.addEventListener('pointerup', (e) => {
+  lightboxImg.releasePointerCapture(e.pointerId);
+  if(isDragging && zoom === 1){
+    const dx = e.clientX - dragStartX;
+    if(Math.abs(dx) > 50) showNext(dx < 0 ? 1 : -1);
+  }
+  isDragging = false;
+});
+lightboxImg?.addEventListener('pointercancel', () => { isDragging = false; });
+
+lightboxImg?.addEventListener('touchstart', (e) => {
+  if(e.touches.length === 2){
+    e.preventDefault();
+    isDragging = false;
+    pinchDist = Math.hypot(
+      e.touches[0].clientX - e.touches[1].clientX,
+      e.touches[0].clientY - e.touches[1].clientY
+    );
+    pinchZoom = zoom;
+  }
+}, {passive:false});
+lightboxImg?.addEventListener('touchmove', (e) => {
+  if(e.touches.length === 2){
+    e.preventDefault();
+    const dist = Math.hypot(
+      e.touches[0].clientX - e.touches[1].clientX,
+      e.touches[0].clientY - e.touches[1].clientY
+    );
+    zoom = Math.min(Math.max(pinchZoom * dist / pinchDist, 1), 5);
+    updateZoom();
+  }
+}, {passive:false});
 
 // Слайдер для карток котеджів
 document.querySelectorAll('.card-gallery').forEach(gal => {

--- a/style.css
+++ b/style.css
@@ -102,7 +102,7 @@ section { padding: 64px 0; }
   z-index: 1000;
 }
 .lightbox.open { display: flex; }
-.lightbox img { max-width: 96vw; max-height: 85vh; border-radius: 12px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
+.lightbox img { max-width: 96vw; max-height: 85vh; border-radius: 12px; box-shadow: 0 20px 60px rgba(0,0,0,.4); touch-action: none; cursor: grab; }
 .lightbox .close { position: absolute; top: 20px; right: 20px; background: white; border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; }
 .lightbox .prev,
 .lightbox .next { position: absolute; top: 50%; transform: translateY(-50%); background: white; border: none; width: 44px; height: 44px; border-radius: 50%; cursor: pointer; font-size: 24px; font-weight: 700; display: none; }


### PR DESCRIPTION
## Summary
- allow gallery images to open as a navigable lightbox
- add pinch, wheel and drag support for zooming
- disable default touch handling on lightbox images

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49106bedc832cb8ad3272c28ac674