### PR TITLE
Fix lightbox arrow and mouse drag

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Перегляд фото">
         <button class="close" id="lightboxClose" aria-label="Закрити">Закрити ✕</button>
         <button class="prev" id="lightboxPrev" aria-label="Попереднє фото">‹</button>
-        <img id="lightboxImg" alt="Збільшене зображення" />
+        <img id="lightboxImg" alt="Збільшене зображення" draggable="false" />
         <button class="next" id="lightboxNext" aria-label="Наступне фото">›</button>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -116,11 +116,13 @@ lightboxImg?.addEventListener('wheel', (e) => {
 
 lightboxImg?.addEventListener('pointerdown', (e) => {
   if(e.pointerType === 'mouse' && e.button !== 0) return;
+  e.preventDefault();
   dragStartX = e.clientX;
   dragStartY = e.clientY;
   isDragging = true;
   lightboxImg.setPointerCapture(e.pointerId);
 });
+lightboxImg?.addEventListener('dragstart', (e) => e.preventDefault());
 lightboxImg?.addEventListener('pointermove', (e) => {
   if(!isDragging) return;
   if(zoom > 1){

--- a/style.css
+++ b/style.css
@@ -102,12 +102,15 @@ section { padding: 64px 0; }
   z-index: 1000;
 }
 .lightbox.open { display: flex; }
-.lightbox img { max-width: 96vw; max-height: 85vh; border-radius: 12px; box-shadow: 0 20px 60px rgba(0,0,0,.4); touch-action: none; cursor: grab; }
+.lightbox img { max-width: 96vw; max-height: 85vh; border-radius: 12px; box-shadow: 0 20px 60px rgba(0,0,0,.4); touch-action: none; cursor: grab; position: relative; z-index: 1; }
 .lightbox .close { position: absolute; top: 20px; right: 20px; background: white; border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; }
 .lightbox .prev,
 .lightbox .next { position: absolute; top: 50%; transform: translateY(-50%); background: white; border: none; width: 44px; height: 44px; border-radius: 50%; cursor: pointer; font-size: 24px; font-weight: 700; display: none; }
 .lightbox .prev { left: 20px; }
 .lightbox .next { right: 20px; }
+.lightbox .close,
+.lightbox .prev,
+.lightbox .next { z-index: 2; }
 
 /* Reviews */
 .review-summary { text-align: center; margin-bottom: 30px; display: grid; gap: 12px; }


### PR DESCRIPTION
## Summary
- ensure lightbox navigation buttons sit above enlarged photos
- prevent default image dragging so zoomed images can be panned with a mouse

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a497046914832cb6f73c5a0c48d181