### PR TITLE
Reset lightbox image position when zooming out

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,6 +49,10 @@ let pinchZoom = 1;
 
 function updateZoom(){
   if(!lightboxImg) return;
+  if(zoom === 1){
+    offsetX = 0;
+    offsetY = 0;
+  }
   lightboxImg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${zoom})`;
   lightboxImg.style.cursor = zoom > 1 ? 'grab' : 'auto';
 }


### PR DESCRIPTION
## Summary
- Reset translate offsets when zoom returns to 1 so images re-center after zooming out

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a499b7ecc0832c8c9b049328068cb7