### PR TITLE
fix: improve lightbox zoom and reset animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,6 +52,9 @@ function updateZoom(){
   if(zoom === 1){
     offsetX = 0;
     offsetY = 0;
+    lightboxImg.style.transition = 'transform 0.3s ease';
+  } else {
+    lightboxImg.style.transition = 'none';
   }
   lightboxImg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${zoom})`;
   lightboxImg.style.cursor = zoom > 1 ? 'grab' : 'auto';
@@ -111,12 +114,12 @@ document.addEventListener('keydown', (e) => {
 });
 
 // Zoom & swipe controls for lightbox image
-lightboxImg?.addEventListener('wheel', (e) => {
+lightbox?.addEventListener('wheel', (e) => {
   e.preventDefault();
   const factor = e.deltaY < 0 ? 1.1 : 0.9;
   zoom = Math.min(Math.max(zoom * factor, 1), 5);
   updateZoom();
-});
+}, { passive: false });
 
 lightboxImg?.addEventListener('pointerdown', (e) => {
   if(e.pointerType === 'mouse' && e.button !== 0) return;


### PR DESCRIPTION
## Summary
- allow lightbox zoom via mouse wheel anywhere in the overlay
- add smooth transform transition when returning zoomed image to its original position

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49c1e57f8832c91a253fa2a154b49