### PR TITLE
Fix review card styles and modal behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -349,7 +349,7 @@ const reviewLightboxClose = document.getElementById('reviewLightboxClose');
 
 function openFullReview(review){
   if(!reviewLightbox || !reviewLightboxContent) return;
-  reviewLightboxContent.innerHTML = reviewHTML(review, true);
+  reviewLightboxContent.innerHTML = `<article class="review-card">${reviewHTML(review, true)}</article>`;
   reviewLightbox.classList.add('open');
   document.body.style.overflow = 'hidden';
 }

--- a/style.css
+++ b/style.css
@@ -120,7 +120,7 @@ section { padding: 64px 0; }
 .review-card .source-icon { width: 24px; height: 24px; border-radius: 50%; }
 .review-summary .overall { display: flex; align-items: center; gap: 8px; justify-content: center; font-weight: 700; }
 .review-carousel { position: relative; }
-.review-grid { display: flex; gap: 20px; overflow-x: auto; scroll-snap-type: x mandatory; scrollbar-width: none; scroll-behavior: smooth; align-items: flex-start; }
+.review-grid { display: flex; gap: 20px; overflow-x: auto; overflow-y: visible; scroll-snap-type: x mandatory; scrollbar-width: none; scroll-behavior: smooth; align-items: flex-start; padding-bottom: 10px; }
 .review-nav { position: absolute; top: 50%; transform: translateY(-50%); background: var(--card); border: none; width: 44px; height: 44px; border-radius: 50%; box-shadow: var(--shadow); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 24px; font-weight: 700; }
 .review-nav.prev { left: -22px; }
 .review-nav.next { right: -22px; }
@@ -130,7 +130,7 @@ section { padding: 64px 0; }
 .review-card .review-header { display: flex; align-items: center; gap: 10px; }
 .review-card .review-header .stars,
 .review-card .review-header .booking-rating { margin-left: auto; }
-.booking-rating { background: #003580; color: #fff; font-weight: 700; padding: 4px 6px; border-radius: 4px; min-width: 32px; text-align: center; }
+.booking-rating { background: #003580; color: #fff; font-weight: 700; padding: 4px 6px; border-radius: 4px 4px 4px 0; min-width: 32px; text-align: center; }
 .review-card .author { font-weight: 700; }
 .review-card .date { font-size: 0.85em; color: var(--muted); }
 .review-card p { margin: 0; }


### PR DESCRIPTION
## Summary
- Adjust Booking.com rating badge to match site styling with sharp bottom-left corner
- Prevent review card shadow from being clipped in carousel
- Ensure "View full review" opens modal with full review content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a590977508832ca78cadddb3fca0d7