### PR TITLE
Ensure full review card shadow is visible without vertical scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -119,13 +119,13 @@ section { padding: 64px 0; }
 .review-summary .source-icon,
 .review-card .source-icon { width: 24px; height: 24px; border-radius: 50%; }
 .review-summary .overall { display: flex; align-items: center; gap: 8px; justify-content: center; font-weight: 700; }
-.review-carousel { position: relative; }
-.review-grid { display: flex; gap: 20px; overflow-x: auto; overflow-y: visible; scroll-snap-type: x mandatory; scrollbar-width: none; scroll-behavior: smooth; align-items: flex-start; padding-bottom: 10px; }
+.review-carousel { position: relative; overflow-x: auto; overflow-y: hidden; scroll-snap-type: x mandatory; scrollbar-width: none; scroll-behavior: smooth; padding-bottom: 40px; }
+.review-grid { display: flex; gap: 20px; align-items: flex-start; }
 .review-nav { position: absolute; top: 50%; transform: translateY(-50%); background: var(--card); border: none; width: 44px; height: 44px; border-radius: 50%; box-shadow: var(--shadow); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 24px; font-weight: 700; }
 .review-nav.prev { left: -22px; }
 .review-nav.next { right: -22px; }
 @media (hover: none) and (pointer: coarse) { .review-nav { display: none; } }
-.review-grid::-webkit-scrollbar { display: none; }
+.review-carousel::-webkit-scrollbar { display: none; }
 .review-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; display: grid; gap: 10px; flex: 0 0 260px; scroll-snap-align: start; }
 .review-card .review-header { display: flex; align-items: center; gap: 10px; }
 .review-card .review-header .stars,


### PR DESCRIPTION
## Summary
- Move horizontal scrolling to `.review-carousel` so its children can overflow vertically
- Add bottom padding to the carousel and remove vertical overflow from the grid so card shadows render fully without vertical scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5974b0f54832ca3a7ca439ba2aa3c