### PR TITLE
Refine review carousel overlay and arrow alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -261,6 +261,11 @@ function renderReviews(){
   const maxHeight = Math.max(...cards.map(c => c.offsetHeight));
   list.style.height = `${maxHeight}px`;
 
+  const minHeight = Math.min(...cards.map(c => c.offsetHeight));
+  document.querySelectorAll('.review-nav').forEach(nav => {
+    nav.style.top = `${minHeight / 2}px`;
+  });
+
   if(list.children.length){
     const gap = parseInt(getComputedStyle(list).columnGap || getComputedStyle(list).gap) || 0;
     const cardWidth = cards[0].offsetWidth + gap;

--- a/style.css
+++ b/style.css
@@ -125,23 +125,16 @@ section { padding: 64px 0; }
   padding-bottom: var(--carousel-bottom-padding);
   overflow: hidden;
 }
-.review-carousel::before,
 .review-carousel::after {
   content: '';
   position: absolute;
   top: 0;
   bottom: var(--carousel-bottom-padding);
+  right: 0;
   width: 40px;
+  background: linear-gradient(to left, var(--bg), transparent);
   pointer-events: none;
   z-index: 1;
-}
-.review-carousel::before {
-  left: 0;
-  background: linear-gradient(to right, var(--bg), transparent);
-}
-.review-carousel::after {
-  right: 0;
-  background: linear-gradient(to left, var(--bg), transparent);
 }
 .review-grid {
   display: flex;
@@ -156,7 +149,7 @@ section { padding: 64px 0; }
 .review-grid::-webkit-scrollbar { display: none; }
 .review-nav {
   position: absolute;
-  top: calc(50% - var(--carousel-bottom-padding) / 2);
+  top: 0;
   transform: translateY(-50%);
   background: var(--card);
   border: none;


### PR DESCRIPTION
## Summary
- remove left gradient mask on review carousel to expose content fully
- dynamically position carousel navigation arrows based on shortest review height
- set initial nav position at top to avoid covering reviews before JS runs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ba425d54832c9c157ee1376d2c87