### PR TITLE
Adjust review carousel overlay and navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,16 +131,17 @@ section { padding: 64px 0; }
   position: absolute;
   top: 0;
   bottom: var(--carousel-bottom-padding);
-  width: 40px;
   pointer-events: none;
   z-index: 1;
 }
 .review-carousel::before {
   left: 0;
+  width: 14px;
   background: linear-gradient(to right, var(--bg), transparent);
 }
 .review-carousel::after {
   right: 0;
+  width: 40px;
   background: linear-gradient(to left, var(--bg), transparent);
 }
 .review-grid {
@@ -156,7 +157,7 @@ section { padding: 64px 0; }
 .review-grid::-webkit-scrollbar { display: none; }
 .review-nav {
   position: absolute;
-  top: calc(50% - var(--carousel-bottom-padding) / 2);
+  top: calc(50% - var(--carousel-bottom-padding) * 1.5);
   transform: translateY(-50%);
   background: var(--card);
   border: none;
@@ -171,6 +172,11 @@ section { padding: 64px 0; }
   font-size: 24px;
   font-weight: 700;
   z-index: 2;
+  opacity: 0.4;
+  transition: opacity 0.2s;
+}
+.review-nav:hover {
+  opacity: 1;
 }
 .review-nav.prev { left: 10px; }
 .review-nav.next { right: 10px; }


### PR DESCRIPTION
## Summary
- Narrow left gradient overlay of review carousel
- Raise and fade review carousel navigation arrows

## Testing
- `npx prettier -c index.html style.css script.js` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c09cddcc832cb71a8e8d7d2f4b11