### PR TITLE
Fix review card shadow clipping

### DIFF
--- a/script.js
+++ b/script.js
@@ -259,11 +259,13 @@ function renderReviews(){
 
   const cards = Array.from(list.children);
   const maxHeight = Math.max(...cards.map(c => c.offsetHeight));
-  list.style.height = `${maxHeight}px`;
+  const carousel = list.parentElement;
+  const padding = parseInt(getComputedStyle(carousel).getPropertyValue('--carousel-bottom-padding')) || 0;
+  list.style.height = `${maxHeight + padding}px`;
 
   const minHeight = Math.min(...cards.map(c => c.offsetHeight));
   document.querySelectorAll('.review-nav').forEach(nav => {
-    nav.style.top = `${minHeight / 2}px`;
+    nav.style.top = `${(minHeight + padding) / 2}px`;
   });
 
   if(list.children.length){

--- a/style.css
+++ b/style.css
@@ -122,8 +122,9 @@ section { padding: 64px 0; }
 .review-carousel {
   --carousel-bottom-padding: 40px;
   position: relative;
+  overflow: visible;
+  overflow-x: hidden;
   padding-bottom: var(--carousel-bottom-padding);
-  overflow: hidden;
 }
 .review-carousel::before,
 .review-carousel::after {
@@ -148,8 +149,8 @@ section { padding: 64px 0; }
   display: flex;
   gap: 20px;
   align-items: flex-start;
+  overflow: visible;
   overflow-x: auto;
-  overflow-y: hidden;
   scroll-snap-type: x mandatory;
   scrollbar-width: none;
   scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
- expand review list height by carousel padding to keep long-card shadows visible
- center review navigation after height adjustment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cdfb56b4832c82fa885a95e91ea9