### PR TITLE
fix: add src attribute to lightbox image

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Перегляд фото">
         <button class="close" id="lightboxClose" aria-label="Закрити">Закрити ✕</button>
         <button class="prev" id="lightboxPrev" aria-label="Попереднє фото">‹</button>
-        <img id="lightboxImg" alt="Збільшене зображення" draggable="false" />
+        <img id="lightboxImg" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Збільшене зображення" draggable="false" />
         <button class="next" id="lightboxNext" aria-label="Наступне фото">›</button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add transparent placeholder src to lightbox image element

## Testing
- `npx htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68a77df56634832c9297b0c3633464c1