### PR TITLE
Display guest capacity with cottage titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,7 @@
               <img src="images/cottage1/cottage1-8.jpg" alt="Котедж #1 фото 8" loading="lazy" />
             </div>
             <div class="card-body">
-              <h2>Котедж #1</h2>
-              <div class="badge">до 6 гостей</div>
+              <h2 class="card-title">Котедж #1 <span class="badge">до 6 гостей</span></h2>
               <div class="features">камін • тераса • кухня • паркінг • Wi‑Fi</div>
               <div class="price">від 3000 грн/ніч</div>
               <div class="actions">
@@ -115,8 +114,7 @@
               <img src="images/cottage2/cottage2-8.jpg" alt="Котедж #2 фото 8" loading="lazy" />
             </div>
             <div class="card-body">
-              <h2>Котедж #2</h2>
-              <div class="badge">до 4 гостей</div>
+              <h2 class="card-title">Котедж #2 <span class="badge">до 4 гостей</span></h2>
               <div class="features">тераса • кухня • дитяче ліжечко • Wi‑Fi</div>
               <div class="price">від 2600 грн/ніч</div>
               <div class="actions">

--- a/style.css
+++ b/style.css
@@ -80,9 +80,10 @@ section { padding: 64px 0; }
 .card-gallery button { position: absolute; top: 50%; transform: translateY(-50%); background: rgba(255,255,255,.8); border: none; width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-weight: 700; z-index: 1; transition: background 0.2s; }
 .card-gallery button:hover { background: var(--card); }
 .card-gallery button.prev { left: 8px; }
-.card-gallery button.next { right: 8px; }
-.card-body { padding: 16px; display: grid; gap: 10px; }
-.badge { display: inline-block; padding: 6px 10px; border-radius: 999px; background: #fdeaea; color: var(--brand-2); font-weight: 700; font-size: 12px; }
+  .card-gallery button.next { right: 8px; }
+  .card-body { padding: 16px; display: grid; gap: 10px; }
+  .card-title { display: flex; align-items: center; gap: 10px; margin: 0; }
+  .badge { flex: 1; display: flex; align-items: center; justify-content: left; padding: 6px 10px; border-radius: 999px; background: #fdeaea; color: var(--brand-2); font-weight: 700; font-size: 12px; }
 .features { display: flex; flex-wrap: wrap; gap: 10px; color: var(--muted); font-size: 14px; }
 .price { font-size: 18px; font-weight: 800; }
 .actions { display: flex; gap: 10px; margin-top: 4px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary
- show guest capacity badges in the same line as cottage names
- stretch badge background across remaining card width for clearer highlight
- left-align badge text within extended title row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ea8b5fc832cbeff571790035e51