### PR TITLE
Add cottage pricing modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
               <div class="features">камін • тераса • кухня • паркінг • Wi‑Fi</div>
               <div class="price">від 3000 грн/ніч</div>
               <div class="actions">
-                <a class="cta" href="tel:+380000000000">Бронювати</a>
+                <button class="cta price-btn" data-cottage="1" type="button">Ціни</button>
                 <a class="cta secondary" href="#contacts">Запитати доступність</a>
               </div>
             </div>
@@ -118,13 +118,17 @@
               <div class="features">тераса • кухня • дитяче ліжечко • Wi‑Fi</div>
               <div class="price">від 2600 грн/ніч</div>
               <div class="actions">
-                <a class="cta" href="tel:+380000000000">Бронювати</a>
+                <button class="cta price-btn" data-cottage="2" type="button">Ціни</button>
                 <a class="cta secondary" href="#contacts">Запитати доступність</a>
               </div>
             </div>
           </article>
         </div>
         <p class="muted" style="margin-top:16px">* Ціни орієнтовні — оновіть під ваші реальні тарифи.</p>
+      </div>
+      <div class="price-lightbox" id="priceLightbox" role="dialog" aria-modal="true" aria-label="Ціни за проживання">
+        <button class="close" id="priceLightboxClose" aria-label="Закрити">Закрити ✕</button>
+        <div id="priceLightboxContent"></div>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -372,4 +372,60 @@ reviewLightboxClose?.addEventListener('click', closeFullReview);
 reviewLightbox?.addEventListener('click', (e) => { if(e.target === reviewLightbox) closeFullReview(); });
 document.addEventListener('keydown', (e) => { if(e.key === 'Escape' && reviewLightbox?.classList.contains('open')) closeFullReview(); });
 
+// Price modal
+const priceLightbox = document.getElementById('priceLightbox');
+const priceLightboxContent = document.getElementById('priceLightboxContent');
+const priceLightboxClose = document.getElementById('priceLightboxClose');
+
+const priceInfo = {
+  1: {
+    title: 'Ціни за добу проживання в Котеджі #1',
+    list: [
+      '6 осіб: 3000 гривень',
+      '5 осіб: 2800 гривень',
+      '4 особи: 2600 гривень',
+      '3 особи: 2400 гривень',
+      '2 особи: 2200 гривень'
+    ]
+  },
+  2: {
+    title: 'Ціни за добу проживання в Котеджі #2',
+    list: [
+      '4 особи: 2600 гривень',
+      '3 особи: 2400 гривень',
+      '2 особи: 2200 гривень'
+    ]
+  },
+  extra: 'Ціна за проживання дітей така ж, як і за проживання дорослих. Домашні улюбленці можуть проживати за додаткову плату 200 гривень за добу.'
+};
+
+function openPrices(id){
+  if(!priceLightbox || !priceLightboxContent) return;
+  const data = priceInfo[id];
+  if(!data) return;
+  const list = data.list.map(item => `<li>${item}</li>`).join('');
+  priceLightboxContent.innerHTML = `
+    <article class="price-card">
+      <h3>${data.title}</h3>
+      <ul class="price-list">${list}</ul>
+      <p>${priceInfo.extra}</p>
+    </article>`;
+  priceLightbox.classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+
+function closePrices(){
+  if(!priceLightbox || !priceLightboxContent) return;
+  priceLightbox.classList.remove('open');
+  priceLightboxContent.innerHTML = '';
+  document.body.style.overflow = '';
+}
+
+document.querySelectorAll('.price-btn').forEach(btn => {
+  btn.addEventListener('click', () => openPrices(btn.dataset.cottage));
+});
+priceLightboxClose?.addEventListener('click', closePrices);
+priceLightbox?.addEventListener('click', (e) => { if(e.target === priceLightbox) closePrices(); });
+document.addEventListener('keydown', (e) => { if(e.key === 'Escape' && priceLightbox?.classList.contains('open')) closePrices(); });
+
 // Хелпер для Viber/Telegram (за потреби)

--- a/style.css
+++ b/style.css
@@ -203,6 +203,14 @@ section { padding: 64px 0; }
 .review-lightbox .close:hover { background: var(--card); }
 .review-lightbox .review-card { max-width: 600px; max-height: 85vh; overflow-y: auto; }
 
+.price-lightbox { position: fixed; inset: 0; background: rgba(0,0,0,.8); display: none; align-items: center; justify-content: center; padding: 24px; z-index: 1000; }
+.price-lightbox.open { display: flex; }
+.price-lightbox .close { position: absolute; top: 20px; right: 20px; background: rgba(255,255,255,.8); border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; transition: background 0.2s; }
+.price-lightbox .close:hover { background: var(--card); }
+.price-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; max-width: 600px; max-height: 85vh; overflow-y: auto; }
+.price-card h3 { margin-top: 0; }
+.price-list { margin: 16px 0; padding-left: 20px; }
+
 /* Contacts */
 .contacts { display: grid; grid-template-columns: 1.1fr .9fr; gap: 20px; }
 .contact-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; }


### PR DESCRIPTION
## Summary
- Rename "Бронювати" buttons to "Ціни" for both cottages and add a shared price modal container.
- Style the pricing modal similar to review lightbox and display per-guest rates with extra notes.
- Implement JavaScript to open/close the modal and render prices for each cottage.

## Testing
- `node --check script.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad75453b70832ca84a42f3244f97d8