### PR TITLE
Use FullCalendar iCal feeds for booking availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,10 +231,6 @@
   }
   </script>
 
-  <script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 
   <link rel="icon" href="favicon.svg" />
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.css" />
 </head>
 <body>
   <a class="sr-only" href="#main">Перейти до основного контенту</a>
@@ -230,6 +231,9 @@
   }
   </script>
 
+  <script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -231,6 +231,10 @@
   }
   </script>
 
+  <script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -231,10 +231,6 @@
   }
   </script>
 
-  <script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js"></script>
-  <script src="script.js"></script>
+  <script src="script.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
   <script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -433,28 +433,37 @@ const calendarLightbox = document.getElementById('calendarLightbox');
 const calendarLightboxContent = document.getElementById('calendarLightboxContent');
 const calendarLightboxClose = document.getElementById('calendarLightboxClose');
 
-const calendarInfo = {
-  1: {
-    title: 'Календар вільних для бронювання дат в Котеджі #1',
-    iframe: '<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=2&ctz=Europe%2FKiev&showPrint=0&title=%D0%9A%D0%BE%D1%82%D0%B5%D0%B4%D0%B6%20%231&showCalendars=0&showTz=0&src=cWkxazZuMjMxMWJiMWZhamxyYmJ1MmUyMjUzZjRrOGtAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23f09300" style="border:solid 1px #777" width="800" height="600"></iframe>'
-  },
-  2: {
-    title: 'Календар вільних для бронювання дат в Котеджі #2',
-    iframe: '<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=2&ctz=Europe%2FKiev&showPrint=0&showCalendars=0&showTz=0&title=%D0%9A%D0%BE%D1%82%D0%B5%D0%B4%D0%B6%20%232&src=NHZpa2hmaWwzY2JoaGtxbmVnaWlhcWtrZjMwa2NoY25AaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23f09300" style="border:solid 1px #777" width="800" height="600"></iframe>'
-  }
+const icsLinks = {
+  1: 'https://ical.booking.com/v1/export?t=efa96061-4119-4efd-8218-b047a22de77f',
+  2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
 };
 
 function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
-  const data = calendarInfo[id];
-  if(!data) return;
+  const url = icsLinks[id];
+  if(!url) return;
   calendarLightboxContent.innerHTML = `
     <article class="calendar-card">
-      <h3>${data.title}</h3>
-      ${data.iframe}
+      <h3>Календар вільних для бронювання дат в Котеджі #${id}</h3>
+      <div id="calendar"></div>
     </article>`;
   calendarLightbox.classList.add('open');
   document.body.style.overflow = 'hidden';
+
+  const calendarEl = document.getElementById('calendar');
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'dayGridMonth',
+    height: 600,
+    displayEventTime: false,
+    events: {
+      url,
+      format: 'ics'
+    },
+    eventDataTransform: (eventData) => ({ ...eventData, title: 'Зайнято' }),
+    eventColor: '#f09300',
+    eventClick: (info) => { info.jsEvent.preventDefault(); }
+  });
+  calendar.render();
 }
 
 function closeCalendar(){

--- a/script.js
+++ b/script.js
@@ -492,13 +492,12 @@ async function openCalendar(id){
     </article>`;
   calendarLightbox.classList.add('open');
   document.body.style.overflow = 'hidden';
-
-  const busyDates = await fetchIcsEvents(url);
   const calendarEl = document.getElementById('calendar');
   const today = new Date();
   today.setHours(0,0,0,0);
   const start = new Date(today.getFullYear(), today.getMonth(), 1);
   const end = new Date(today.getFullYear(), today.getMonth() + 12, 0);
+  let busyDates = new Set();
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     height: 600,
@@ -524,6 +523,13 @@ async function openCalendar(id){
     }
   });
   calendar.render();
+
+  try {
+    busyDates = await fetchIcsEvents(url);
+    calendar.rerenderDates();
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 function closeCalendar(){

--- a/script.js
+++ b/script.js
@@ -489,10 +489,10 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'today prev title next', center: '', right: '' },
+    headerToolbar: { left: 'prev title next', center: '', right: 'today' },
     buttonText: { today: 'Сьогодні' },
     titleFormat: { year: 'numeric', month: 'long' },
-    titleDidMount: (arg) => { arg.el.textContent = arg.el.textContent.replace(' р.', ''); },
+    titleDidMount: (arg) => { arg.el.textContent = arg.el.textContent.replace(/\s*р\.$/, ''); },
     validRange: { start, end },
     dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : []
   });

--- a/script.js
+++ b/script.js
@@ -489,8 +489,10 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
+    headerToolbar: { left: 'today prev title next', center: '', right: '' },
     buttonText: { today: 'Сьогодні' },
+    titleFormat: { year: 'numeric', month: 'long' },
+    titleDidMount: (arg) => { arg.el.textContent = arg.el.textContent.replace(' р.', ''); },
     validRange: { start, end },
     dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : []
   });

--- a/script.js
+++ b/script.js
@@ -489,7 +489,7 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'prev title next', center: '', right: 'today' },
+    headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
     buttonText: { today: 'Сьогодні' },
     titleFormat: { year: 'numeric', month: 'long' },
     titleDidMount: (arg) => { arg.el.textContent = arg.el.textContent.replace(/\s*р\.$/, ''); },
@@ -497,6 +497,14 @@ async function openCalendar(id){
     dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : []
   });
   calendar.render();
+  const toolbar = calendarEl.querySelector('.fc-header-toolbar');
+  const todayBtn = toolbar?.querySelector('.fc-today-button');
+  if (toolbar && todayBtn) {
+    const wrap = document.createElement('div');
+    wrap.className = 'fc-today-wrap';
+    wrap.appendChild(todayBtn);
+    toolbar.appendChild(wrap);
+  }
 }
 
 function closeCalendar(){

--- a/script.js
+++ b/script.js
@@ -433,6 +433,31 @@ const calendarLightbox = document.getElementById('calendarLightbox');
 const calendarLightboxContent = document.getElementById('calendarLightboxContent');
 const calendarLightboxClose = document.getElementById('calendarLightboxClose');
 
+function loadScript(src){
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+}
+
+let calendarLibsPromise;
+function ensureCalendarLibs(){
+  if(!calendarLibsPromise){
+    calendarLibsPromise = (async () => {
+      if(!window.ICAL) await loadScript('https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js');
+      if(!window.FullCalendar){
+        await loadScript('https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js');
+        await loadScript('https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js');
+        await loadScript('https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js');
+      }
+    })();
+  }
+  return calendarLibsPromise;
+}
+
 const icsLinks = {
   1: 'https://ical.booking.com/v1/export?t=efa96061-4119-4efd-8218-b047a22de77f',
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
@@ -484,6 +509,17 @@ async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
   if(!url) return;
+  try {
+    await ensureCalendarLibs();
+  } catch (e) {
+    console.error(e);
+  }
+  if(!window.FullCalendar){
+    calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
+    calendarLightbox.classList.add('open');
+    document.body.style.overflow = 'hidden';
+    return;
+  }
   calendarLightboxContent.innerHTML = `
     <article class="calendar-card">
       <h3>Календар вільних для бронювання дат в Котеджі #${id}</h3>

--- a/script.js
+++ b/script.js
@@ -438,6 +438,27 @@ const icsLinks = {
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
 };
 
+async function loadCalendarDeps(){
+  if (window.FullCalendar && window.ICAL) return;
+  const urls = [
+    'https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js',
+    'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js',
+    'https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js',
+    'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js'
+  ];
+  for (const src of urls){
+    if (!document.querySelector(`script[src="${src}"]`)){
+      await new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = src;
+        s.onload = resolve;
+        s.onerror = reject;
+        document.head.appendChild(s);
+      });
+    }
+  }
+}
+
 function dateKey(d){
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
 }
@@ -484,6 +505,14 @@ async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
   if(!url) return;
+  try {
+    await loadCalendarDeps();
+  } catch (e) {
+    calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
+    calendarLightbox.classList.add('open');
+    document.body.style.overflow = 'hidden';
+    return;
+  }
   if (typeof FullCalendar === 'undefined' || typeof ICAL === 'undefined') {
     calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
     calendarLightbox.classList.add('open');

--- a/script.js
+++ b/script.js
@@ -496,6 +496,7 @@ async function openCalendar(id){
   const busyDates = await fetchIcsEvents(url);
   const calendarEl = document.getElementById('calendar');
   const today = new Date();
+  today.setHours(0,0,0,0);
   const start = new Date(today.getFullYear(), today.getMonth(), 1);
   const end = new Date(today.getFullYear(), today.getMonth() + 12, 0);
   const calendar = new FullCalendar.Calendar(calendarEl, {
@@ -505,7 +506,7 @@ async function openCalendar(id){
     firstDay: 1,
     headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
     buttonText: { today: 'Сьогодні' },
-    titleFormat: { year: 'numeric', month: 'long' },
+    titleFormat: (arg) => new Intl.DateTimeFormat('uk', { month: 'long', year: 'numeric' }).format(arg.date).replace(' р.', ''),
     validRange: { start, end },
     dayCellClassNames: (arg) => {
       const cls = [];
@@ -520,8 +521,6 @@ async function openCalendar(id){
     },
     datesSet: () => {
       placeTodayBtn(calendarEl);
-      const titleEl = calendarEl.querySelector('.fc-toolbar-title');
-      if (titleEl) titleEl.textContent = titleEl.textContent.replace(/\s*р\.$/, '');
     }
   });
   calendar.render();

--- a/script.js
+++ b/script.js
@@ -503,13 +503,26 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'prev', center: 'title', right: 'next' },
+    headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
     buttonText: { today: 'Сьогодні' },
     titleFormat: { year: 'numeric', month: 'long' },
-    titleDidMount: (arg) => { arg.el.textContent = arg.el.textContent.replace(/\s*р\.$/, ''); },
     validRange: { start, end },
-    dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : [],
-    datesSet: () => placeTodayBtn(calendarEl)
+    dayCellClassNames: (arg) => {
+      const cls = [];
+      if (busyDates.has(dateKey(arg.date))) cls.push('occupied');
+      const viewStart = arg.view.currentStart;
+      if (
+        arg.date < today &&
+        arg.date.getMonth() === viewStart.getMonth() &&
+        arg.date.getFullYear() === viewStart.getFullYear()
+      ) cls.push('past');
+      return cls;
+    },
+    datesSet: () => {
+      placeTodayBtn(calendarEl);
+      const titleEl = calendarEl.querySelector('.fc-toolbar-title');
+      if (titleEl) titleEl.textContent = titleEl.textContent.replace(/\s*р\.$/, '');
+    }
   });
   calendar.render();
 }

--- a/script.js
+++ b/script.js
@@ -445,20 +445,21 @@ async function fetchIcsEvents(url){
     const text = await res.text();
     const jcal = ICAL.parse(text);
     const comp = new ICAL.Component(jcal);
-    return comp.getAllSubcomponents('vevent').flatMap(v => {
+    const busy = new Set();
+    comp.getAllSubcomponents('vevent').forEach(v => {
       const ev = new ICAL.Event(v);
-      const dates = [];
       let day = ev.startDate.toJSDate();
       const end = ev.endDate.toJSDate();
       while (day < end) {
-        dates.push({ start: new Date(day), allDay: true, display: 'background' });
+        const d = new Date(day.getFullYear(), day.getMonth(), day.getDate());
+        busy.add(d.toISOString().split('T')[0]);
         day.setDate(day.getDate() + 1);
       }
-      return dates;
     });
+    return busy;
   } catch (e) {
     console.error('Не вдалося завантажити календар', e);
-    return [];
+    return new Set();
   }
 }
 
@@ -475,7 +476,7 @@ async function openCalendar(id){
   calendarLightbox.classList.add('open');
   document.body.style.overflow = 'hidden';
 
-  const events = await fetchIcsEvents(url);
+  const busyDates = await fetchIcsEvents(url);
   const calendarEl = document.getElementById('calendar');
   const today = new Date();
   const start = new Date(today.getFullYear(), today.getMonth(), 1);
@@ -483,19 +484,15 @@ async function openCalendar(id){
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     height: 600,
-    displayEventTime: false,
-    events,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'today', center: 'prev,title,next', right: '' },
+    headerToolbar: { left: '', center: 'prev,title,next', right: 'today' },
     buttonText: { today: 'Сьогодні' },
     validRange: { start, end },
-    eventDidMount: (info) => {
-      const cell = info.el.closest('.fc-daygrid-day');
-      if (cell) cell.classList.add('occupied');
-      info.el.style.display = 'none';
-    },
-    eventClick: (info) => { info.jsEvent.preventDefault(); }
+    dayCellDidMount: (info) => {
+      const iso = info.date.toISOString().split('T')[0];
+      if (busyDates.has(iso)) info.el.classList.add('occupied');
+    }
   });
   calendar.render();
 }

--- a/script.js
+++ b/script.js
@@ -438,25 +438,6 @@ const icsLinks = {
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
 };
 
-let calendarLibsPromise;
-function loadCalendarLibs(){
-  if(calendarLibsPromise) return calendarLibsPromise;
-  const sources = [
-    'https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js',
-    'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js',
-    'https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js',
-    'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js'
-  ];
-  calendarLibsPromise = Promise.all(sources.map(src => new Promise((resolve, reject) => {
-    const s = document.createElement('script');
-    s.src = src;
-    s.onload = resolve;
-    s.onerror = reject;
-    document.head.appendChild(s);
-  })));
-  return calendarLibsPromise;
-}
-
 function dateKey(d){
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
 }
@@ -503,15 +484,7 @@ async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
   if(!url) return;
-  try {
-    await loadCalendarLibs();
-  } catch (e) {
-    calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
-    calendarLightbox.classList.add('open');
-    document.body.style.overflow = 'hidden';
-    return;
-  }
-  if(!window.FullCalendar || !window.ICAL){
+  if (typeof FullCalendar === 'undefined' || typeof ICAL === 'undefined') {
     calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
     calendarLightbox.classList.add('open');
     document.body.style.overflow = 'hidden';

--- a/script.js
+++ b/script.js
@@ -433,31 +433,6 @@ const calendarLightbox = document.getElementById('calendarLightbox');
 const calendarLightboxContent = document.getElementById('calendarLightboxContent');
 const calendarLightboxClose = document.getElementById('calendarLightboxClose');
 
-function loadScript(src){
-  return new Promise((resolve, reject) => {
-    const s = document.createElement('script');
-    s.src = src;
-    s.onload = resolve;
-    s.onerror = reject;
-    document.head.appendChild(s);
-  });
-}
-
-let calendarLibsPromise;
-function ensureCalendarLibs(){
-  if(!calendarLibsPromise){
-    calendarLibsPromise = (async () => {
-      if(!window.ICAL) await loadScript('https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js');
-      if(!window.FullCalendar){
-        await loadScript('https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js');
-        await loadScript('https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js');
-        await loadScript('https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js');
-      }
-    })();
-  }
-  return calendarLibsPromise;
-}
-
 const icsLinks = {
   1: 'https://ical.booking.com/v1/export?t=efa96061-4119-4efd-8218-b047a22de77f',
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
@@ -509,12 +484,7 @@ async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
   if(!url) return;
-  try {
-    await ensureCalendarLibs();
-  } catch (e) {
-    console.error(e);
-  }
-  if(!window.FullCalendar){
+  if(!window.FullCalendar || !window.ICAL){
     calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
     calendarLightbox.classList.add('open');
     document.body.style.overflow = 'hidden';

--- a/script.js
+++ b/script.js
@@ -438,6 +438,10 @@ const icsLinks = {
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
 };
 
+function dateKey(d){
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+
 async function fetchIcsEvents(url){
   try {
     const proxyUrl = `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(url)}`;
@@ -451,8 +455,7 @@ async function fetchIcsEvents(url){
       let day = ev.startDate.toJSDate();
       const end = ev.endDate.toJSDate();
       while (day < end) {
-        const d = new Date(day.getFullYear(), day.getMonth(), day.getDate());
-        busy.add(d.toISOString().split('T')[0]);
+        busy.add(dateKey(day));
         day.setDate(day.getDate() + 1);
       }
     });
@@ -486,13 +489,10 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: '', center: 'prev,title,next', right: 'today' },
+    headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
     buttonText: { today: 'Сьогодні' },
     validRange: { start, end },
-    dayCellDidMount: (info) => {
-      const iso = info.date.toISOString().split('T')[0];
-      if (busyDates.has(iso)) info.el.classList.add('occupied');
-    }
+    dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : []
   });
   calendar.render();
 }

--- a/script.js
+++ b/script.js
@@ -438,6 +438,25 @@ const icsLinks = {
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
 };
 
+let calendarLibsPromise;
+function loadCalendarLibs(){
+  if(calendarLibsPromise) return calendarLibsPromise;
+  const sources = [
+    'https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js',
+    'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js',
+    'https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js',
+    'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js'
+  ];
+  calendarLibsPromise = Promise.all(sources.map(src => new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = reject;
+    document.head.appendChild(s);
+  })));
+  return calendarLibsPromise;
+}
+
 function dateKey(d){
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
 }
@@ -484,6 +503,14 @@ async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
   if(!url) return;
+  try {
+    await loadCalendarLibs();
+  } catch (e) {
+    calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
+    calendarLightbox.classList.add('open');
+    document.body.style.overflow = 'hidden';
+    return;
+  }
   if(!window.FullCalendar || !window.ICAL){
     calendarLightboxContent.innerHTML = `<article class="calendar-card"><p>Не вдалося завантажити календар.</p></article>`;
     calendarLightbox.classList.add('open');

--- a/script.js
+++ b/script.js
@@ -438,7 +438,23 @@ const icsLinks = {
   2: 'https://ical.booking.com/v1/export?t=34812d3f-ed21-4935-ab56-76452c38388f'
 };
 
-function openCalendar(id){
+async function fetchIcsEvents(url){
+  const res = await fetch(url);
+  const text = await res.text();
+  const jcal = ICAL.parse(text);
+  const comp = new ICAL.Component(jcal);
+  return comp.getAllSubcomponents('vevent').map(v => {
+    const ev = new ICAL.Event(v);
+    return {
+      title: 'Зайнято',
+      start: ev.startDate.toJSDate(),
+      end: ev.endDate.toJSDate(),
+      allDay: ev.startDate.isDate
+    };
+  });
+}
+
+async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
   if(!url) return;
@@ -450,17 +466,14 @@ function openCalendar(id){
   calendarLightbox.classList.add('open');
   document.body.style.overflow = 'hidden';
 
+  const events = await fetchIcsEvents(url);
   const calendarEl = document.getElementById('calendar');
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     height: 600,
     displayEventTime: false,
-    events: {
-      url,
-      format: 'ics'
-    },
-    eventDataTransform: (eventData) => ({ ...eventData, title: 'Зайнято' }),
-    eventColor: '#f09300',
+    events,
+    eventColor: '#d64045',
     eventClick: (info) => { info.jsEvent.preventDefault(); }
   });
   calendar.render();

--- a/script.js
+++ b/script.js
@@ -445,14 +445,16 @@ async function fetchIcsEvents(url){
     const text = await res.text();
     const jcal = ICAL.parse(text);
     const comp = new ICAL.Component(jcal);
-    return comp.getAllSubcomponents('vevent').map(v => {
+    return comp.getAllSubcomponents('vevent').flatMap(v => {
       const ev = new ICAL.Event(v);
-      return {
-        start: ev.startDate.toJSDate(),
-        end: ev.endDate.toJSDate(),
-        allDay: ev.startDate.isDate,
-        display: 'background'
-      };
+      const dates = [];
+      let day = ev.startDate.toJSDate();
+      const end = ev.endDate.toJSDate();
+      while (day < end) {
+        dates.push({ start: new Date(day), allDay: true, display: 'background' });
+        day.setDate(day.getDate() + 1);
+      }
+      return dates;
     });
   } catch (e) {
     console.error('Не вдалося завантажити календар', e);
@@ -485,7 +487,8 @@ async function openCalendar(id){
     events,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: '', center: 'prev,title', right: 'today next' },
+    headerToolbar: { left: 'today', center: 'prev,title,next', right: '' },
+    buttonText: { today: 'Сьогодні' },
     validRange: { start, end },
     eventDidMount: (info) => {
       const cell = info.el.closest('.fc-daygrid-day');

--- a/script.js
+++ b/script.js
@@ -466,6 +466,20 @@ async function fetchIcsEvents(url){
   }
 }
 
+function placeTodayBtn(calendarEl){
+  const toolbar = calendarEl.querySelector('.fc-header-toolbar');
+  const todayBtn = toolbar?.querySelector('.fc-today-button');
+  if (!toolbar || !todayBtn) return;
+  let wrap = calendarEl.querySelector('.fc-today-wrap');
+  if (!wrap){
+    wrap = document.createElement('div');
+    wrap.className = 'fc-today-wrap';
+    toolbar.after(wrap);
+  }
+  wrap.innerHTML = '';
+  wrap.appendChild(todayBtn);
+}
+
 async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
@@ -489,22 +503,15 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
+    headerToolbar: { left: 'prev', center: 'title', right: 'next' },
     buttonText: { today: 'Сьогодні' },
     titleFormat: { year: 'numeric', month: 'long' },
     titleDidMount: (arg) => { arg.el.textContent = arg.el.textContent.replace(/\s*р\.$/, ''); },
     validRange: { start, end },
-    dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : []
+    dayCellClassNames: (arg) => busyDates.has(dateKey(arg.date)) ? ['occupied'] : [],
+    datesSet: () => placeTodayBtn(calendarEl)
   });
   calendar.render();
-  const toolbar = calendarEl.querySelector('.fc-header-toolbar');
-  const todayBtn = toolbar?.querySelector('.fc-today-button');
-  if (toolbar && todayBtn) {
-    const wrap = document.createElement('div');
-    wrap.className = 'fc-today-wrap';
-    wrap.appendChild(todayBtn);
-    toolbar.appendChild(wrap);
-  }
 }
 
 function closeCalendar(){

--- a/script.js
+++ b/script.js
@@ -440,7 +440,7 @@ const icsLinks = {
 
 async function fetchIcsEvents(url){
   try {
-    const proxyUrl = `https://cors.isomorphic-git.org/${url}`;
+    const proxyUrl = `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(url)}`;
     const res = await fetch(proxyUrl);
     const text = await res.text();
     const jcal = ICAL.parse(text);

--- a/script.js
+++ b/script.js
@@ -448,10 +448,10 @@ async function fetchIcsEvents(url){
     return comp.getAllSubcomponents('vevent').map(v => {
       const ev = new ICAL.Event(v);
       return {
-        title: 'Зайнято',
         start: ev.startDate.toJSDate(),
         end: ev.endDate.toJSDate(),
-        allDay: ev.startDate.isDate
+        allDay: ev.startDate.isDate,
+        display: 'background'
       };
     });
   } catch (e) {
@@ -468,18 +468,30 @@ async function openCalendar(id){
     <article class="calendar-card">
       <h3>Календар вільних для бронювання дат в Котеджі #${id}</h3>
       <div id="calendar"></div>
+      <div class="legend"><div class="legend-item free"><span></span> Вільно</div><div class="legend-item busy"><span></span> Зайнято</div></div>
     </article>`;
   calendarLightbox.classList.add('open');
   document.body.style.overflow = 'hidden';
 
   const events = await fetchIcsEvents(url);
   const calendarEl = document.getElementById('calendar');
+  const today = new Date();
+  const start = new Date(today.getFullYear(), today.getMonth(), 1);
+  const end = new Date(today.getFullYear(), today.getMonth() + 12, 0);
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     height: 600,
     displayEventTime: false,
     events,
-    eventColor: '#d64045',
+    locale: 'uk',
+    firstDay: 1,
+    headerToolbar: { left: '', center: 'prev,title', right: 'today next' },
+    validRange: { start, end },
+    eventDidMount: (info) => {
+      const cell = info.el.closest('.fc-daygrid-day');
+      if (cell) cell.classList.add('occupied');
+      info.el.style.display = 'none';
+    },
     eventClick: (info) => { info.jsEvent.preventDefault(); }
   });
   calendar.render();

--- a/script.js
+++ b/script.js
@@ -439,19 +439,25 @@ const icsLinks = {
 };
 
 async function fetchIcsEvents(url){
-  const res = await fetch(url);
-  const text = await res.text();
-  const jcal = ICAL.parse(text);
-  const comp = new ICAL.Component(jcal);
-  return comp.getAllSubcomponents('vevent').map(v => {
-    const ev = new ICAL.Event(v);
-    return {
-      title: 'Зайнято',
-      start: ev.startDate.toJSDate(),
-      end: ev.endDate.toJSDate(),
-      allDay: ev.startDate.isDate
-    };
-  });
+  try {
+    const proxyUrl = `https://cors.isomorphic-git.org/${url}`;
+    const res = await fetch(proxyUrl);
+    const text = await res.text();
+    const jcal = ICAL.parse(text);
+    const comp = new ICAL.Component(jcal);
+    return comp.getAllSubcomponents('vevent').map(v => {
+      const ev = new ICAL.Event(v);
+      return {
+        title: 'Зайнято',
+        start: ev.startDate.toJSDate(),
+        end: ev.endDate.toJSDate(),
+        allDay: ev.startDate.isDate
+      };
+    });
+  } catch (e) {
+    console.error('Не вдалося завантажити календар', e);
+    return [];
+  }
 }
 
 async function openCalendar(id){

--- a/style.css
+++ b/style.css
@@ -243,14 +243,46 @@ section { padding: 64px 0; }
   --fc-button-border-color: var(--brand);
   --fc-button-hover-bg-color: var(--brand-2);
   --fc-button-hover-border-color: var(--brand-2);
-  --fc-event-bg-color: var(--brand);
-  --fc-event-border-color: var(--brand);
   --fc-today-bg-color: #fdeaea;
 }
 
 .calendar-card .fc .fc-button {
   border-radius: 8px;
   box-shadow: var(--shadow);
+}
+
+.calendar-card .fc-daygrid-day.occupied {
+  background: var(--brand);
+  border-color: var(--brand);
+}
+.calendar-card .fc-daygrid-day.occupied .fc-daygrid-day-number {
+  color: #fff;
+}
+
+.calendar-card .legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 14px;
+}
+.calendar-card .legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.calendar-card .legend-item span {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #e2ddd5;
+  border-radius: 4px;
+  display: block;
+}
+.calendar-card .legend-item.free span {
+  background: var(--card);
+}
+.calendar-card .legend-item.busy span {
+  background: var(--brand);
+  border-color: var(--brand);
 }
 
 /* Contacts */

--- a/style.css
+++ b/style.css
@@ -243,14 +243,14 @@ section { padding: 64px 0; }
   --fc-button-border-color: var(--brand);
   --fc-button-hover-bg-color: var(--brand-2);
   --fc-button-hover-border-color: var(--brand-2);
-  --fc-today-bg-color: #fdeaea;
+  --fc-today-bg-color: rgba(214, 64, 69, 0.15);
 }
 
 .calendar-card .fc-header-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   margin-bottom: 12px;
 }
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk {
@@ -259,6 +259,11 @@ section { padding: 64px 0; }
   gap: 8px;
   flex: none;
   flex-direction: row;
+}
+.calendar-card .fc-today-wrap {
+  width: 100%;
+  margin-top: 8px;
+  text-align: left;
 }
 .calendar-card .fc-toolbar-title {
   font-size: 24px;
@@ -270,11 +275,14 @@ section { padding: 64px 0; }
 }
 
 .calendar-card .fc-daygrid-day.occupied {
-  background: var(--brand);
-  border-color: var(--brand);
+  background: #fdeaea;
+  border-color: #fdeaea;
 }
 .calendar-card .fc-daygrid-day.occupied .fc-daygrid-day-number {
-  color: #fff;
+  color: var(--brand-2);
+}
+.calendar-card .fc-day-today .fc-daygrid-day-number {
+  font-size: 2em;
 }
 
 .calendar-card .legend {
@@ -299,8 +307,8 @@ section { padding: 64px 0; }
   background: var(--card);
 }
 .calendar-card .legend-item.busy span {
-  background: var(--brand);
-  border-color: var(--brand);
+  background: #fdeaea;
+  border-color: #fdeaea;
 }
 
 /* Contacts */

--- a/style.css
+++ b/style.css
@@ -249,7 +249,7 @@ section { padding: 64px 0; }
 .calendar-card .fc-header-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   flex-wrap: nowrap;
   margin-bottom: 12px;
 }
@@ -257,6 +257,7 @@ section { padding: 64px 0; }
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: none;
   flex-direction: row;
 }
 .calendar-card .fc-toolbar-title {

--- a/style.css
+++ b/style.css
@@ -257,6 +257,10 @@ section { padding: 64px 0; }
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-direction: row;
+}
+.calendar-card .fc-toolbar-title {
+  font-size: 24px;
 }
 
 .calendar-card .fc .fc-button {

--- a/style.css
+++ b/style.css
@@ -5,6 +5,7 @@
   --muted: #6b6459;
   --brand: #d64045;
   --brand-2: #8b2c34;
+  --brand-disabled: #e48386;
   --ring: rgba(214, 64, 69, 0.25);
   --shadow: 0 10px 25px rgba(0,0,0,.08);
   --radius: 16px;
@@ -287,11 +288,14 @@ section { padding: 64px 0; }
   color: var(--brand-2);
 }
 .calendar-card .fc-daygrid-day.occupied {
-  background: var(--brand);
-  border-color: var(--brand);
+  background: var(--brand-disabled);
+  border-color: var(--brand-disabled);
 }
 .calendar-card .fc-daygrid-day.occupied .fc-daygrid-day-number {
   color: #fff;
+}
+.calendar-card .fc-daygrid-day.past .fc-daygrid-day-number {
+  opacity: .3;
 }
 .calendar-card .fc-day-today .fc-daygrid-day-number {
   font-size: 2em;
@@ -319,8 +323,8 @@ section { padding: 64px 0; }
   background: var(--card);
 }
 .calendar-card .legend-item.busy span {
-  background: var(--brand);
-  border-color: var(--brand);
+  background: var(--brand-disabled);
+  border-color: var(--brand-disabled);
 }
 
 /* Contacts */

--- a/style.css
+++ b/style.css
@@ -250,15 +250,24 @@ section { padding: 64px 0; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   margin-bottom: 12px;
 }
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex: none;
-  flex-direction: row;
+}
+.calendar-card .fc-header-toolbar .fc-toolbar-chunk:nth-child(2) {
+  flex: 1;
+  justify-content: center;
+}
+
+.calendar-card .fc-theme-standard th {
+  background: #fdeaea;
+}
+.calendar-card .fc-col-header-cell-cushion {
+  color: var(--brand-2);
 }
 .calendar-card .fc-today-wrap {
   width: 100%;
@@ -274,12 +283,15 @@ section { padding: 64px 0; }
   box-shadow: var(--shadow);
 }
 
+.calendar-card .fc-daygrid-day-number {
+  color: var(--brand-2);
+}
 .calendar-card .fc-daygrid-day.occupied {
-  background: #fdeaea;
-  border-color: #fdeaea;
+  background: var(--brand);
+  border-color: var(--brand);
 }
 .calendar-card .fc-daygrid-day.occupied .fc-daygrid-day-number {
-  color: var(--brand-2);
+  color: #fff;
 }
 .calendar-card .fc-day-today .fc-daygrid-day-number {
   font-size: 2em;
@@ -307,8 +319,8 @@ section { padding: 64px 0; }
   background: var(--card);
 }
 .calendar-card .legend-item.busy span {
-  background: #fdeaea;
-  border-color: #fdeaea;
+  background: var(--brand);
+  border-color: var(--brand);
 }
 
 /* Contacts */

--- a/style.css
+++ b/style.css
@@ -249,7 +249,7 @@ section { padding: 64px 0; }
 .calendar-card .fc-header-toolbar {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   flex-wrap: nowrap;
   margin-bottom: 12px;
 }

--- a/style.css
+++ b/style.css
@@ -272,7 +272,7 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc-today-wrap {
   width: 100%;
-  margin-top: 8px;
+  margin: 0 0 8px;
   text-align: left;
 }
 .calendar-card .fc-toolbar-title {

--- a/style.css
+++ b/style.css
@@ -232,7 +232,7 @@ section { padding: 64px 0; }
 .calendar-lightbox .close:hover { background: var(--card); }
 .calendar-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; max-width: 800px; max-height: 90vh; overflow-y: auto; }
 .calendar-card h3 { margin-top: 0; margin-bottom: 16px; }
-.calendar-card iframe { width: 100%; height: 600px; border: 0; }
+.calendar-card #calendar { width: 100%; height: 600px; }
 
 /* Contacts */
 .contacts { display: grid; grid-template-columns: 1.1fr .9fr; gap: 20px; }

--- a/style.css
+++ b/style.css
@@ -246,6 +246,19 @@ section { padding: 64px 0; }
   --fc-today-bg-color: #fdeaea;
 }
 
+.calendar-card .fc-header-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  margin-bottom: 12px;
+}
+.calendar-card .fc-header-toolbar .fc-toolbar-chunk {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .calendar-card .fc .fc-button {
   border-radius: 8px;
   box-shadow: var(--shadow);

--- a/style.css
+++ b/style.css
@@ -234,6 +234,25 @@ section { padding: 64px 0; }
 .calendar-card h3 { margin-top: 0; margin-bottom: 16px; }
 .calendar-card #calendar { width: 100%; height: 600px; }
 
+.calendar-card .fc {
+  --fc-border-color: #e2ddd5;
+  --fc-page-bg-color: var(--card);
+  --fc-neutral-bg-color: var(--bg);
+  --fc-button-text-color: #fff;
+  --fc-button-bg-color: var(--brand);
+  --fc-button-border-color: var(--brand);
+  --fc-button-hover-bg-color: var(--brand-2);
+  --fc-button-hover-border-color: var(--brand-2);
+  --fc-event-bg-color: var(--brand);
+  --fc-event-border-color: var(--brand);
+  --fc-today-bg-color: #fdeaea;
+}
+
+.calendar-card .fc .fc-button {
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
 /* Contacts */
 .contacts { display: grid; grid-template-columns: 1.1fr .9fr; gap: 20px; }
 .contact-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; }


### PR DESCRIPTION
## Summary
- replace embedded Google Calendars with FullCalendar powered iCal feeds
- load Booking.com iCal links for each cottage and show events as "Зайнято"

## Testing
- `node --check script.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb02f7a34832c8cac42818b8c8c27