### PR TITLE
Fix calendar past date highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -490,6 +490,7 @@ async function openCalendar(id){
   const busyDates = await fetchIcsEvents(url);
   const calendarEl = document.getElementById('calendar');
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const start = new Date(today.getFullYear(), today.getMonth(), 1);
   const end = new Date(today.getFullYear(), today.getMonth() + 12, 0);
   const calendar = new FullCalendar.Calendar(calendarEl, {


### PR DESCRIPTION
## Summary
- Ensure today's date is not treated as past in booking calendar

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af0a7e82a4832cb09077ad977de149