### PR TITLE
Fix calendar title duplication when switching months

### DIFF
--- a/script.js
+++ b/script.js
@@ -513,10 +513,10 @@ async function openCalendar(id){
       ) cls.push('past');
       return cls;
     },
-    datesSet: () => {
+    datesSet: (info) => {
       placeTodayBtn(calendarEl);
       const titleEl = calendarEl.querySelector('.fc-toolbar-title');
-      if (titleEl) titleEl.textContent = titleEl.textContent.replace(/\s*р\.$/, '');
+      if (titleEl) titleEl.textContent = info.view.title.replace(/\s*р\.$/, '');
     }
   });
   calendar.render();


### PR DESCRIPTION
## Summary
- Prevent month names from stacking in the calendar modal by replacing the title with the current view's title each time dates change.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af100be7d4832ca897e7db2b101ff2