### PR TITLE
Align Today button with calendar header

### DIFF
--- a/script.js
+++ b/script.js
@@ -462,19 +462,6 @@ async function fetchIcsEvents(url){
     return new Set();
   }
 }
-function placeTodayBtn(calendarEl){
-  const toolbar = calendarEl.querySelector('.fc-header-toolbar');
-  const todayBtn = toolbar?.querySelector('.fc-today-button');
-  if (!toolbar || !todayBtn) return;
-  let wrap = calendarEl.querySelector('.fc-today-wrap');
-  if (!wrap){
-    wrap = document.createElement('div');
-    wrap.className = 'fc-today-wrap';
-    toolbar.after(wrap);
-  }
-  wrap.innerHTML = '';
-  wrap.appendChild(todayBtn);
-}
 async function openCalendar(id){
   if(!calendarLightbox || !calendarLightboxContent) return;
   const url = icsLinks[id];
@@ -498,7 +485,7 @@ async function openCalendar(id){
     height: 600,
     locale: 'uk',
     firstDay: 1,
-    headerToolbar: { left: 'prev', center: 'title', right: 'next today' },
+    headerToolbar: { left: 'prev today', center: 'title', right: 'next' },
     buttonText: { today: 'Сьогодні' },
     titleFormat: { year: 'numeric', month: 'long' },
     validRange: { start, end },
@@ -514,7 +501,6 @@ async function openCalendar(id){
       return cls;
     },
     datesSet: (info) => {
-      placeTodayBtn(calendarEl);
       const titleEl = calendarEl.querySelector('.fc-toolbar-title');
       if (titleEl) titleEl.textContent = info.view.title.replace(/\s*р\.$/, '');
     }

--- a/style.css
+++ b/style.css
@@ -267,11 +267,6 @@ section { padding: 64px 0; }
 .calendar-card .fc-col-header-cell-cushion {
   color: var(--brand-2);
 }
-.calendar-card .fc-today-wrap {
-  width: 100%;
-  margin-top: 8px;
-  text-align: left;
-}
 .calendar-card .fc-toolbar-title {
   font-size: 24px;
 }


### PR DESCRIPTION
## Summary
- Place the "Today" button next to the left navigation arrow in the calendar modal
- Remove unused wrapper styling for the old Today button placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af11c686d8832caa40d3c2042277a1