### PR TITLE
Align Today button under prev arrow in calendar modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -466,11 +466,13 @@ function placeTodayBtn(calendarEl){
   const toolbar = calendarEl.querySelector('.fc-header-toolbar');
   const todayBtn = toolbar?.querySelector('.fc-today-button');
   if (!toolbar || !todayBtn) return;
-  let wrap = calendarEl.querySelector('.fc-today-wrap');
+  const leftChunk = toolbar.querySelector('.fc-toolbar-chunk:first-child');
+  if (!leftChunk) return;
+  let wrap = leftChunk.querySelector('.fc-today-wrap');
   if (!wrap){
     wrap = document.createElement('div');
     wrap.className = 'fc-today-wrap';
-    toolbar.after(wrap);
+    leftChunk.appendChild(wrap);
   }
   wrap.innerHTML = '';
   wrap.appendChild(todayBtn);

--- a/style.css
+++ b/style.css
@@ -247,7 +247,7 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc-header-toolbar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   flex-wrap: nowrap;
   margin-bottom: 12px;

--- a/style.css
+++ b/style.css
@@ -257,6 +257,10 @@ section { padding: 64px 0; }
   align-items: center;
   gap: 8px;
 }
+.calendar-card .fc-header-toolbar .fc-toolbar-chunk:first-child {
+  flex-direction: column;
+  align-items: flex-start;
+}
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk:nth-child(2) {
   flex: 1;
   justify-content: center;
@@ -268,9 +272,7 @@ section { padding: 64px 0; }
   color: var(--brand-2);
 }
 .calendar-card .fc-today-wrap {
-  width: 100%;
   margin-top: 8px;
-  text-align: left;
 }
 .calendar-card .fc-toolbar-title {
   font-size: 24px;

--- a/style.css
+++ b/style.css
@@ -250,6 +250,7 @@ section { padding: 64px 0; }
   align-items: flex-start;
   justify-content: space-between;
   flex-wrap: nowrap;
+  padding-bottom: 40px;
   margin-bottom: 12px;
 }
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk {
@@ -258,6 +259,7 @@ section { padding: 64px 0; }
   gap: 8px;
 }
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk:first-child {
+  position: relative;
   flex-direction: column;
   align-items: flex-start;
 }
@@ -272,7 +274,14 @@ section { padding: 64px 0; }
   color: var(--brand-2);
 }
 .calendar-card .fc-today-wrap {
-  margin-top: 8px;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+}
+.calendar-card .fc-prev-button,
+.calendar-card .fc-next-button,
+.calendar-card .fc-today-button {
+  margin: 0;
 }
 .calendar-card .fc-toolbar-title {
   font-size: 24px;

--- a/style.css
+++ b/style.css
@@ -275,7 +275,7 @@ section { padding: 64px 0; }
 .calendar-card .fc-col-header-cell-cushion {
   color: var(--brand-2);
 }
-.calendar-card .fc-today-wrap {
+.calendar-card .fc-header-toolbar .fc-toolbar-chunk .fc-today-wrap {
   position: absolute;
   top: calc(100% + 8px);
   left: 0;

--- a/style.css
+++ b/style.css
@@ -262,6 +262,8 @@ section { padding: 64px 0; }
   position: relative;
   flex-direction: column;
   align-items: flex-start;
+  margin-left: 0;
+  padding-left: 0;
 }
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk:nth-child(2) {
   flex: 1;
@@ -277,6 +279,7 @@ section { padding: 64px 0; }
   position: absolute;
   top: calc(100% + 8px);
   left: 0;
+  margin-left: 0;
 }
 .calendar-card .fc-prev-button,
 .calendar-card .fc-next-button,


### PR DESCRIPTION
## Summary
- Reposition the FullCalendar "Today" button beneath the previous-month arrow
- Adjust toolbar layout to stack controls vertically and add spacing above calendar grid

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af13e7c5c8832c9f630434cffd797a