### PR TITLE
Fix hover underlining on buttons and calendar

### DIFF
--- a/style.css
+++ b/style.css
@@ -66,6 +66,10 @@ header {
   box-shadow: var(--shadow);
 }
 .cta.secondary { background: #fdeaea; color: var(--brand-2); }
+.cta:hover,
+.cta:focus {
+  text-decoration: none;
+}
 .hero-card { position: relative; background: var(--card); border-radius: 24px; overflow: hidden; box-shadow: var(--shadow); }
 .hero-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
@@ -297,6 +301,10 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc-col-header-cell-cushion {
   color: var(--brand-2);
+}
+.calendar-card a:hover,
+.calendar-card a:focus {
+  text-decoration: none;
 }
 .calendar-card .fc-header-toolbar .fc-toolbar-chunk .fc-today-wrap {
   position: absolute;


### PR DESCRIPTION
## Summary
- keep call-to-action buttons from gaining underline on hover
- remove underline hover effect for calendar dates and weekday headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07a879880832cb4fcfb41257d26e7