### PR TITLE
feat: add hover effects to contact and calendar buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -259,8 +259,11 @@ section { padding: 64px 0; }
     --fc-button-text-color: var(--brand-2);
     --fc-button-bg-color: #fdeaea;
     --fc-button-border-color: #fdeaea;
-    --fc-button-hover-bg-color: #fdeaea;
-    --fc-button-hover-border-color: #fdeaea;
+    --fc-button-hover-bg-color: #fcd5d5;
+    --fc-button-hover-border-color: #fcd5d5;
+    --fc-button-active-bg-color: #fcd5d5;
+    --fc-button-active-border-color: #fcd5d5;
+    --fc-button-focus-box-shadow: none;
     --fc-today-bg-color: rgba(214, 64, 69, 0.15);
   }
 .calendar-card .fc-header-toolbar {
@@ -318,6 +321,7 @@ section { padding: 64px 0; }
   font-weight: 700;
   padding: 8px 16px;
   transition: background-color 0.3s, transform 0.2s;
+  outline: none;
 }
 .calendar-card .fc .fc-button:enabled:hover {
   transform: translateY(-2px) scale(1.05);
@@ -325,6 +329,11 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc .fc-button:enabled:active {
   transform: scale(0.95);
+  background: #fcd5d5;
+}
+.calendar-card .fc .fc-button:focus {
+  outline: none;
+  box-shadow: var(--shadow);
 }
 .calendar-card .fc-daygrid-day-number {
   color: var(--brand-2);

--- a/style.css
+++ b/style.css
@@ -334,6 +334,10 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc .fc-button:focus {
   outline: none;
+  box-shadow: none;
+}
+
+.calendar-card .fc .fc-button:focus-visible {
   box-shadow: 0 0 0 2px var(--brand-2);
 }
 .calendar-card .fc-daygrid-day-number {

--- a/style.css
+++ b/style.css
@@ -64,11 +64,24 @@ header {
   border: none;
   cursor: pointer;
   box-shadow: var(--shadow);
+  transition: background-color 0.3s, transform 0.2s;
 }
 .cta.secondary { background: #fdeaea; color: var(--brand-2); }
 .cta:hover,
 .cta:focus {
   text-decoration: none;
+}
+.cta:hover {
+  transform: translateY(-2px) scale(1.05);
+}
+.cta:active {
+  transform: scale(0.95);
+}
+.cta:not(.secondary):hover {
+  background: var(--brand-2);
+}
+.cta.secondary:hover {
+  background: #fcd5d5;
 }
 .hero-card { position: relative; background: var(--card); border-radius: 24px; overflow: hidden; box-shadow: var(--shadow); }
 .hero-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
@@ -108,28 +121,6 @@ section { padding: 64px 0; }
 .price { font-size: 18px; font-weight: 800; }
 .actions { display: flex; gap: 10px; margin-top: 4px; flex-wrap: wrap; }
 
-.price-btn,
-.calendar-btn {
-  transition: background-color 0.3s, transform 0.2s;
-}
-
-.price-btn:hover,
-.calendar-btn:hover {
-  transform: translateY(-2px) scale(1.05);
-}
-
-.price-btn:active,
-.calendar-btn:active {
-  transform: scale(0.95);
-}
-
-.price-btn:hover {
-  background: var(--brand-2);
-}
-
-.calendar-btn:hover {
-  background: #fcd5d5;
-}
 
 /* Gallery */
 .masonry { column-count: 3; column-gap: 16px; }
@@ -326,6 +317,14 @@ section { padding: 64px 0; }
   box-shadow: var(--shadow);
   font-weight: 700;
   padding: 8px 16px;
+  transition: background-color 0.3s, transform 0.2s;
+}
+.calendar-card .fc .fc-button:enabled:hover {
+  transform: translateY(-2px) scale(1.05);
+  background: #fcd5d5;
+}
+.calendar-card .fc .fc-button:enabled:active {
+  transform: scale(0.95);
 }
 .calendar-card .fc-daygrid-day-number {
   color: var(--brand-2);

--- a/style.css
+++ b/style.css
@@ -263,7 +263,7 @@ section { padding: 64px 0; }
     --fc-button-hover-border-color: #fcd5d5;
     --fc-button-active-bg-color: #fcd5d5;
     --fc-button-active-border-color: #fcd5d5;
-    --fc-button-focus-box-shadow: none;
+    --fc-button-focus-box-shadow: 0 0 0 2px var(--brand-2);
     --fc-today-bg-color: rgba(214, 64, 69, 0.15);
   }
 .calendar-card .fc-header-toolbar {
@@ -330,10 +330,11 @@ section { padding: 64px 0; }
 .calendar-card .fc .fc-button:enabled:active {
   transform: scale(0.95);
   background: #fcd5d5;
+  box-shadow: 0 0 0 2px var(--brand-2);
 }
 .calendar-card .fc .fc-button:focus {
   outline: none;
-  box-shadow: var(--shadow);
+  box-shadow: 0 0 0 2px var(--brand-2);
 }
 .calendar-card .fc-daygrid-day-number {
   color: var(--brand-2);


### PR DESCRIPTION
## Summary
- add hover and active transitions for primary and secondary CTA buttons
- animate calendar navigation and today buttons when enabled

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b16c18d46c832cb862c75acf052c49