### PR TITLE
Remove tap highlight on mobile buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,9 @@ body {
 a { color: var(--brand); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
+/* Remove tap highlight on touch devices */
+a, button { -webkit-tap-highlight-color: transparent; }
+
 .container { max-width: var(--container); margin: 0 auto; padding: 0 20px; }
 
 /* Header */


### PR DESCRIPTION
## Summary
- eliminate blue overlay on touch by disabling WebKit tap highlight on links and buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b18cbf165c832cbd8f0f4ba92f2c22