### PR TITLE
Ensure today's free date cell uses uniform color in calendar

### DIFF
--- a/style.css
+++ b/style.css
@@ -356,6 +356,10 @@ section { padding: 64px 0; }
 .calendar-card .fc-daygrid-day.past .fc-daygrid-day-number {
   opacity: .3;
 }
+.calendar-card .fc-day-today {
+  background: var(--card);
+  border-color: var(--fc-border-color);
+}
 .calendar-card .fc-day-today .fc-daygrid-day-number {
   font-size: 2em;
 }


### PR DESCRIPTION
## Summary
- Override FullCalendar's default highlighting to remove unique styling for the current day when it is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b18f5d4bcc832ca7b7b140b89eb5e8