### PR TITLE
Fix today's date color in booking calendar

### DIFF
--- a/style.css
+++ b/style.css
@@ -356,6 +356,9 @@ section { padding: 64px 0; }
 .calendar-card .fc-daygrid-day.past .fc-daygrid-day-number {
   opacity: .3;
 }
+.calendar-card .fc-day-today:not(.occupied) {
+  background: var(--card);
+}
 .calendar-card .fc-day-today .fc-daygrid-day-number {
   font-size: 2em;
 }


### PR DESCRIPTION
## Summary
- prevent today's available date from appearing with a different background in the booking calendar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b19267005c832c8665af0971f7d8b2