### PR TITLE
Show operation years in footer

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,11 @@
-// Поточний рік у футері
+// Роки у футері
 document.addEventListener('DOMContentLoaded', () => {
   const y = document.getElementById('year');
-  if (y) y.textContent = new Date().getFullYear();
+  if (y) {
+    const startYear = 2006;
+    const currentYear = new Date().getFullYear();
+    y.textContent = currentYear === startYear ? String(startYear) : `${startYear}-${currentYear}`;
+  }
 });
 
 // Мобільне меню


### PR DESCRIPTION
## Summary
- display both start year (2006) and current year in footer, dynamically updating

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a10b9af4832ca4467207d7f11468