### PR TITLE
Fix stuck hover state on calendar buttons for touch screens

### DIFF
--- a/script.js
+++ b/script.js
@@ -526,12 +526,14 @@ async function openCalendar(id){
     }
   });
   calendar.render();
-
-  calendarEl.addEventListener('pointerup', (e) => {
-    if (e.pointerType === 'touch') {
-      e.target.closest('.fc-button')?.blur();
-    }
-  });
+  if (window.matchMedia('(hover: none)').matches) {
+    calendarEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.fc-button');
+      if (btn) {
+        setTimeout(() => btn.blur());
+      }
+    });
+  }
 }
 function closeCalendar(){
   if(!calendarLightbox || !calendarLightboxContent) return;

--- a/script.js
+++ b/script.js
@@ -526,6 +526,12 @@ async function openCalendar(id){
     }
   });
   calendar.render();
+
+  calendarEl.addEventListener('pointerup', (e) => {
+    if (e.pointerType === 'touch') {
+      e.target.closest('.fc-button')?.blur();
+    }
+  });
 }
 function closeCalendar(){
   if(!calendarLightbox || !calendarLightboxContent) return;

--- a/style.css
+++ b/style.css
@@ -326,9 +326,11 @@ section { padding: 64px 0; }
   transition: background-color 0.3s, transform 0.2s;
   outline: none;
 }
-.calendar-card .fc .fc-button:enabled:hover {
-  transform: translateY(-2px) scale(1.05);
-  background: #fcd5d5;
+@media (hover: hover) {
+  .calendar-card .fc .fc-button:enabled:hover {
+    transform: translateY(-2px) scale(1.05);
+    background: #fcd5d5;
+  }
 }
 .calendar-card .fc .fc-button:enabled:active {
   transform: scale(0.95);

--- a/style.css
+++ b/style.css
@@ -326,11 +326,9 @@ section { padding: 64px 0; }
   transition: background-color 0.3s, transform 0.2s;
   outline: none;
 }
-@media (hover: hover) {
-  .calendar-card .fc .fc-button:enabled:hover {
-    transform: translateY(-2px) scale(1.05);
-    background: #fcd5d5;
-  }
+.calendar-card .fc .fc-button:enabled:hover {
+  transform: translateY(-2px) scale(1.05);
+  background: #fcd5d5;
 }
 .calendar-card .fc .fc-button:enabled:active {
   transform: scale(0.95);


### PR DESCRIPTION
## Summary
- Prevent calendar navigation buttons from keeping hover background after touch by applying hover styles only when the device supports hover.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a39b13a4832ca61cf5f675a4acb7