### PR TITLE
feat: animate calendar navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -541,6 +541,7 @@ function setupCalendarNav(calendarEl, calendar){
     const oldView = fcRoot.querySelector('.fc-view-harness-active');
     if(!oldView) return;
     const clone = oldView.cloneNode(true);
+    clone.classList.remove('fc-view-harness-active');
     clone.classList.add('fc-slide-old');
     fcRoot.appendChild(clone);
 
@@ -608,10 +609,34 @@ function setupCalendarNav(calendarEl, calendar){
     startX = null;
   });
   fcRoot.addEventListener('pointercancel', () => { startX = null; });
+
+  fcRoot.addEventListener('touchstart', (e) => {
+    if(e.touches.length === 1){
+      startX = e.touches[0].clientX;
+    }
+  }, {passive:true});
+  fcRoot.addEventListener('touchend', (e) => {
+    if(startX === null) return;
+    const diff = e.changedTouches[0].clientX - startX;
+    if(Math.abs(diff) > 50){
+      slide(diff < 0 ? 1 : -1);
+    }
+    startX = null;
+  });
+
+  const handleKey = (e) => {
+    if(e.key === 'ArrowLeft') { e.preventDefault(); slide(-1); }
+    if(e.key === 'ArrowRight') { e.preventDefault(); slide(1); }
+  };
+  document.addEventListener('keydown', handleKey);
+  calendarEl._calKeyHandler = handleKey;
 }
 
 function closeCalendar(){
   if(!calendarLightbox || !calendarLightboxContent) return;
+  const calEl = document.getElementById('calendar');
+  const h = calEl?._calKeyHandler;
+  if(h) document.removeEventListener('keydown', h);
   calendarLightbox.classList.remove('open');
   calendarLightboxContent.innerHTML = '';
   document.body.style.overflow = '';

--- a/script.js
+++ b/script.js
@@ -584,18 +584,30 @@ function setupCalendarNav(calendarEl, calendar){
 
   const prevBtn = fcRoot.querySelector('.fc-prev-button');
   const nextBtn = fcRoot.querySelector('.fc-next-button');
-  prevBtn?.addEventListener('click', (e) => { e.preventDefault(); slide(-1); });
-  nextBtn?.addEventListener('click', (e) => { e.preventDefault(); slide(1); });
+  prevBtn?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    slide(-1);
+  });
+  nextBtn?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    slide(1);
+  });
 
-  fcRoot.addEventListener('touchstart', (e) => { startX = e.touches[0].clientX; });
-  fcRoot.addEventListener('touchend', (e) => {
+  fcRoot.addEventListener('pointerdown', (e) => {
+    if(e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
+    startX = e.clientX;
+  });
+  fcRoot.addEventListener('pointerup', (e) => {
     if(startX === null) return;
-    const diff = e.changedTouches[0].clientX - startX;
+    const diff = e.clientX - startX;
     if(Math.abs(diff) > 50){
       slide(diff < 0 ? 1 : -1);
     }
     startX = null;
   });
+  fcRoot.addEventListener('pointercancel', () => { startX = null; });
 }
 
 function closeCalendar(){

--- a/script.js
+++ b/script.js
@@ -530,7 +530,74 @@ async function openCalendar(id){
     }
   });
   calendar.render();
+  setupCalendarNav(calendarEl, calendar);
 }
+
+function setupCalendarNav(calendarEl, calendar){
+  const fcRoot = calendarEl.querySelector('.fc');
+  if(!fcRoot) return;
+  let startX = null;
+  function slide(dir){
+    const oldView = fcRoot.querySelector('.fc-view-harness-active');
+    if(!oldView) return;
+    const clone = oldView.cloneNode(true);
+    clone.classList.add('fc-slide-old');
+    fcRoot.appendChild(clone);
+
+    const titleEl = fcRoot.querySelector('.fc-toolbar-title');
+    const titleParent = titleEl?.parentElement;
+    const titleClone = titleEl?.cloneNode(true);
+    if(titleClone && titleParent){
+      titleClone.classList.add('fc-title-old');
+      titleParent.appendChild(titleClone);
+    }
+
+    calendar[dir > 0 ? 'next' : 'prev']();
+
+    const newView = fcRoot.querySelector('.fc-view-harness-active');
+    if(newView){
+      newView.classList.add('fc-slide-new');
+      newView.style.transform = `translateX(${dir * 100}%)`;
+    }
+    if(titleEl){
+      titleEl.style.transform = `translateX(${dir * 100}%)`;
+    }
+
+    requestAnimationFrame(() => {
+      clone.style.transform = `translateX(${dir * -100}%)`;
+      if(newView) newView.style.transform = 'translateX(0)';
+      if(titleClone) titleClone.style.transform = `translateX(${dir * -100}%)`;
+      if(titleEl) titleEl.style.transform = 'translateX(0)';
+    });
+
+    const cleanup = () => {
+      clone.remove();
+      titleClone?.remove();
+      if(newView){
+        newView.classList.remove('fc-slide-new');
+        newView.style.transform = '';
+      }
+      if(titleEl) titleEl.style.transform = '';
+    };
+    clone.addEventListener('transitionend', cleanup, { once: true });
+  }
+
+  const prevBtn = fcRoot.querySelector('.fc-prev-button');
+  const nextBtn = fcRoot.querySelector('.fc-next-button');
+  prevBtn?.addEventListener('click', (e) => { e.preventDefault(); slide(-1); });
+  nextBtn?.addEventListener('click', (e) => { e.preventDefault(); slide(1); });
+
+  fcRoot.addEventListener('touchstart', (e) => { startX = e.touches[0].clientX; });
+  fcRoot.addEventListener('touchend', (e) => {
+    if(startX === null) return;
+    const diff = e.changedTouches[0].clientX - startX;
+    if(Math.abs(diff) > 50){
+      slide(diff < 0 ? 1 : -1);
+    }
+    startX = null;
+  });
+}
+
 function closeCalendar(){
   if(!calendarLightbox || !calendarLightboxContent) return;
   calendarLightbox.classList.remove('open');

--- a/style.css
+++ b/style.css
@@ -254,7 +254,29 @@ section { padding: 64px 0; }
 .calendar-lightbox .close:hover { background: var(--card); }
 .calendar-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; max-width: 800px; max-height: 90vh; overflow-y: auto; }
 .calendar-card h3 { margin-top: 0; margin-bottom: 16px; }
-.calendar-card #calendar { width: 100%; height: 600px; }
+.calendar-card #calendar { width: 100%; height: 600px; position: relative; overflow: hidden; }
+.calendar-card #calendar::before,
+.calendar-card #calendar::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 24px;
+  pointer-events: none;
+  z-index: 2;
+}
+.calendar-card #calendar::before { left: 0; background: linear-gradient(to right, var(--card), rgba(255,255,255,0)); }
+.calendar-card #calendar::after { right: 0; background: linear-gradient(to left, var(--card), rgba(255,255,255,0)); }
+.calendar-card #calendar .fc { position: relative; }
+.calendar-card #calendar .fc-slide-old,
+.calendar-card #calendar .fc-slide-new {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transition: transform 0.3s ease;
+}
+.calendar-card #calendar .fc-slide-old { pointer-events: none; }
 .calendar-card .fc {
     --fc-border-color: #e2ddd5;
     --fc-page-bg-color: var(--card);
@@ -316,6 +338,33 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc-toolbar-title {
   font-size: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.calendar-card .fc-toolbar-title::before,
+.calendar-card .fc-toolbar-title::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 16px;
+  pointer-events: none;
+  background: linear-gradient(to right, var(--card), rgba(255,255,255,0));
+}
+.calendar-card .fc-toolbar-title::after {
+  right: 0;
+  left: auto;
+  transform: scaleX(-1);
+}
+.calendar-card .fc-title-old,
+.calendar-card .fc-toolbar-title {
+  transition: transform 0.3s ease;
+}
+.calendar-card .fc-title-old {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
 }
 .calendar-card .fc .fc-button {
   border: none;


### PR DESCRIPTION
## Summary
- add sliding transition and touch swipe navigation for calendar modal
- smooth month title animation with gradient edges
- style calendar container with edge gradients

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c4ccb668832c8dffe5643a8b1fc6