### PR TITLE
Fix calendar row height consistency

### DIFF
--- a/style.css
+++ b/style.css
@@ -367,9 +367,7 @@ section { padding: 64px 0; }
 }
 .calendar-card .fc-day-today .fc-daygrid-day-number {
   display: inline-block;
-  font-size: 1em;
-  transform: scale(1.5);
-  transform-origin: center;
+  font-size: 1.5em;
 }
 .calendar-card .legend {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -343,6 +343,12 @@ section { padding: 64px 0; }
 .calendar-card .fc .fc-button:focus-visible {
   box-shadow: 0 0 0 2px var(--brand-2);
 }
+.calendar-card .fc-daygrid-day-top {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 32px;
+}
 .calendar-card .fc-daygrid-day-number {
   color: var(--brand-2);
 }
@@ -360,7 +366,10 @@ section { padding: 64px 0; }
   background: var(--card);
 }
 .calendar-card .fc-day-today .fc-daygrid-day-number {
-  font-size: 2em;
+  display: inline-block;
+  font-size: 1em;
+  transform: scale(1.5);
+  transform-origin: center;
 }
 .calendar-card .legend {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -346,11 +346,12 @@ section { padding: 64px 0; }
 .calendar-card .fc-daygrid-day-top {
   display: flex;
   justify-content: flex-end;
-  align-items: center;
+  align-items: flex-start;
   height: 32px;
 }
 .calendar-card .fc-daygrid-day-number {
   color: var(--brand-2);
+  line-height: 1;
 }
 .calendar-card .fc-daygrid-day.occupied {
   background: var(--brand-disabled);


### PR DESCRIPTION
## Summary
- Ensure calendar day rows have uniform height
- Keep today's date visually larger via scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70af3d800832cb2fe4678eb153f96