### PR TITLE
Highlight active header sections with smooth nav animations

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,6 +33,23 @@ document.querySelectorAll('a[href^="#"]').forEach(a => {
   });
 });
 
+// Підсвічування пунктів меню при скролі
+const sections = document.querySelectorAll('main section[id]');
+const navLinks = document.querySelectorAll('.menu a');
+
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if(entry.isIntersecting){
+      const id = entry.target.getAttribute('id');
+      navLinks.forEach(link => {
+        link.classList.toggle('active', link.getAttribute('href') === `#${id}`);
+      });
+    }
+  });
+}, { threshold: 0.4 });
+
+sections.forEach(section => observer.observe(section));
+
 // Лайтбокс для галереї
 const gallery = document.getElementById('galleryGrid');
 const lightbox = document.getElementById('lightbox');

--- a/style.css
+++ b/style.css
@@ -43,8 +43,21 @@ header {
 .brand { display: flex; align-items: center; gap: 10px; font-weight: 700; }
 .brand-logo { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, var(--brand-2), var(--brand)); box-shadow: var(--shadow); }
 .menu { display: flex; align-items: center; gap: 18px; }
-.menu a { font-weight: 600; color: var(--text); opacity: .9; }
+.menu a {
+  display: inline-block;
+  font-weight: 600;
+  color: var(--text);
+  opacity: .9;
+  text-decoration: none;
+  transition: color 0.3s, transform 0.3s;
+}
 .menu a.active { color: var(--brand); }
+.menu a:hover,
+.menu a:focus,
+.menu a:active {
+  text-decoration: none;
+  transform: scale(1.1);
+}
 .hamburger { display: none; width: 40px; height: 40px; border: 1px solid #e2ddd5; border-radius: 10px; background: var(--card); align-items: center; justify-content: center; }
 
 /* Hero */

--- a/style.css
+++ b/style.css
@@ -53,7 +53,6 @@ header {
 }
 .menu a.active { color: var(--brand); }
 .menu a:hover,
-.menu a:focus,
 .menu a:active {
   text-decoration: none;
   transform: scale(1.1);


### PR DESCRIPTION
## Summary
- Remove text underline on header navigation and add scale/color transitions for hover and active states
- Highlight navigation link of section in view using IntersectionObserver scroll spy
- Adjust scroll spy threshold

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b84114baf4832ca6ebcd7941473572