### PR TITLE
Widen calendar modal on large screens

### DIFF
--- a/script.js
+++ b/script.js
@@ -579,7 +579,9 @@ document.querySelectorAll('.calendar-btn').forEach(btn => {
   btn.addEventListener('click', () => openCalendar(btn.dataset.cottage));
 });
 calendarLightboxClose?.addEventListener('click', closeCalendar);
-calendarLightbox?.addEventListener('click', (e) => { if(e.target === calendarLightbox) closeCalendar(); });
+calendarLightbox?.addEventListener('click', (e) => {
+  if (!e.target.closest('.calendar-card')) closeCalendar();
+});
 document.addEventListener('keydown', (e) => { if(e.key === 'Escape' && calendarLightbox?.classList.contains('open')) closeCalendar(); });
 
 // Хелпер для Viber/Telegram (за потреби)

--- a/style.css
+++ b/style.css
@@ -289,7 +289,8 @@ section { padding: 64px 0; }
 .calendar-lightbox.open { display: flex; }
 .calendar-lightbox .close { position: absolute; top: 20px; right: 20px; background: rgba(255,255,255,.8); border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; transition: background 0.2s; }
 .calendar-lightbox .close:hover { background: var(--card); }
-.calendar-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; max-width: 800px; max-height: 90vh; overflow-y: auto; }
+#calendarLightboxContent { width: 100%; display: flex; justify-content: center; }
+.calendar-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; width: 100%; max-width: 800px; max-height: 90vh; overflow-y: auto; }
 .calendar-card h3 { margin-top: 0; margin-bottom: 16px; }
 .calendar-card #calendar { width: 100%; height: 600px; }
 .calendar-card .fc {


### PR DESCRIPTION
## Summary
- Expand calendar modal width by stretching lightbox content to full width and centering the calendar card
- Constrain calendar modal to a maximum width of 800px on large displays
- Allow closing the calendar modal by clicking outside the calendar card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba929830ec832cb35f33fb76619acb