### PR TITLE
Remove margin from contact hours text

### DIFF
--- a/style.css
+++ b/style.css
@@ -473,6 +473,7 @@ section { padding: 64px 0; }
   grid-template-columns: repeat(2, 1fr);
 }
 .contact-section { display: grid; gap: 12px; align-content: start; }
+.contact-section p { margin: 0; }
 .contact-list { display: grid; gap: 12px; font-size: 16px; }
 .contact-list a { font-weight: 600; }
 .contact-list div { display: flex; align-items: center; gap: 8px; }


### PR DESCRIPTION
## Summary
- Remove default top and bottom margin from contact hours paragraph in Contacts section

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d0be3c8c832c851e0459880a8fc2