### PR TITLE
feat: display relative review dates

### DIFF
--- a/script.js
+++ b/script.js
@@ -296,7 +296,25 @@ function renderStars(r){
 }
 
 function formatDate(str){
-  return new Date(str).toLocaleDateString('uk-UA', { day: 'numeric', month: 'short', year: 'numeric' });
+  const date = new Date(str);
+  const now = new Date();
+  const diff = date - now;
+  const rtf = new Intl.RelativeTimeFormat('uk', { numeric: 'always' });
+  const units = [
+    { unit: 'year', ms: 1000 * 60 * 60 * 24 * 365 },
+    { unit: 'month', ms: 1000 * 60 * 60 * 24 * 30 },
+    { unit: 'week', ms: 1000 * 60 * 60 * 24 * 7 },
+    { unit: 'day', ms: 1000 * 60 * 60 * 24 },
+    { unit: 'hour', ms: 1000 * 60 * 60 },
+    { unit: 'minute', ms: 1000 * 60 }
+  ];
+  for (const {unit, ms} of units) {
+    const value = diff / ms;
+    if (Math.abs(value) >= 1) {
+      return rtf.format(Math.round(value), unit);
+    }
+  }
+  return rtf.format(0, 'second');
 }
 
 function formatBookingScore(r){


### PR DESCRIPTION
## Summary
- show review dates in relative format using `Intl.RelativeTimeFormat`

## Testing
- `node -e "function formatDate(str){ const date=new Date(str); const now=new Date(); const diff=date-now; const rtf=new Intl.RelativeTimeFormat('uk',{numeric:'always'}); const units=[{unit:'year',ms:31536000000},{unit:'month',ms:2592000000},{unit:'week',ms:604800000},{unit:'day',ms:86400000},{unit:'hour',ms:3600000},{unit:'minute',ms:60000}]; for(const {unit,ms} of units){const value=diff/ms; if(Math.abs(value)>=1)return rtf.format(Math.round(value),unit);} return rtf.format(0,'second');} console.log(formatDate('2023-07-21')); console.log(formatDate('2025-08-22'));"`

------
https://chatgpt.com/codex/tasks/task_e_68c3ebfeabdc832cb443a7eaa483f1a6