### PR TITLE
Show zoom cursor on cottage images

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,6 +131,7 @@ section { padding: 64px 0; }
   width: 100%;
   height: 100%;
   object-fit: cover;
+  cursor: zoom-in;
   display: none;
 }
 .card-gallery img.active { display: block; }


### PR DESCRIPTION
## Summary
- Show zoom-in cursor when hovering over cottage card images to match gallery behavior

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f6c11ce8832cb609eb172a3e7ec8