### PR TITLE
Remove lightbox frame background

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,14 +179,14 @@ section { padding: 64px 0; }
 .lightbox-frame {
   max-width: 96vw;
   max-height: 85vh;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0,0,0,.4);
+  border-radius: 0;
+  box-shadow: none;
   overflow: hidden;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
+  background: transparent;
   will-change: transform, opacity;
 }
 .lightbox-frame.is-transitioning { pointer-events: none; }


### PR DESCRIPTION
## Summary
- remove the semi-transparent background on the lightbox frame to prevent visible side borders around photos
- drop the lightbox frame shadow and rounding so the frame no longer shows behind images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caa296ce34832ca03e9b856ce6cf8c