### PR TITLE
Fix FullCalendar stylesheet CDN URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="style.css" />
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/index.global.min.css"
+    href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.css"
   />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- update FullCalendar stylesheet CDN link to the correct package path

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3e9f53ae4832ca5134701131a6a61