### PR TITLE
Remove nonexistent FullCalendar CSS link

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,7 @@
 
   <link rel="icon" href="favicon.svg" />
   <link rel="stylesheet" href="style.css" />
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/index.global.min.css"
-  />
+  <!-- FullCalendar's global bundle injects its own base styles -->
 </head>
 <body>
   <a class="sr-only" href="#main">Перейти до основного контенту</a>


### PR DESCRIPTION
## Summary
- remove the invalid FullCalendar CDN stylesheet link that returned 404 errors
- add a clarifying comment noting that the global bundle already injects its base styles

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3e9f53ae4832ca5134701131a6a61