### PR TITLE
Remove unused FullCalendar CDN references

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
 
   <link rel="icon" href="favicon.svg" />
   <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.css" />
 </head>
 <body>
   <a class="sr-only" href="#main">Перейти до основного контенту</a>
@@ -332,7 +331,6 @@
   <script src="https://cdn.jsdelivr.net/npm/ical.js@1.4.0/build/ical.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.11/index.global.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/uk.global.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop the unused FullCalendar stylesheet reference so the page stops requesting the missing CSS asset
- remove the Ukrainian locale CDN script include that produced a 404

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d40e5a9c4c832cbef5a1e0ef9e819e