### PR TITLE
Add privacy policy modal and footer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,9 +308,9 @@
   </main>
 
   <footer>
-    <div class="container">
-      © <span id="year"></span> Котедж Ватра. Всі права захищено.
+    <div class="container footer-content">
       <a href="#" id="privacyLink" class="footer-link">Політика приватності</a>
+      <p>© <span id="year"></span> Котедж Ватра. Всі права захищено.</p>
     </div>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -308,8 +308,30 @@
   </main>
 
   <footer>
-    <div class="container">© <span id="year"></span> Котедж Ватра. Всі права захищено.</div>
+    <div class="container">
+      © <span id="year"></span> Котедж Ватра. Всі права захищено.
+      <a href="#" id="privacyLink" class="footer-link">Політика приватності</a>
+    </div>
   </footer>
+
+  <div
+    class="privacy-lightbox"
+    id="privacyLightbox"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="privacyTitle"
+  >
+    <button class="close" id="privacyLightboxClose" aria-label="Закрити">Закрити ✕</button>
+    <article class="privacy-card" role="document">
+      <h3 id="privacyTitle">Політика приватності</h3>
+      <p>
+        На цьому сайті використовується Google Analytics для збору статистики відвідувань. Google може збирати інформацію через
+        файли cookie та інші технології. Детальніше:
+        <a href="https://www.google.com/policies/privacy/partners/" target="_blank" rel="noopener noreferrer">Як Google використовує дані</a>.
+        Ми не збираємо та не зберігаємо персональні дані відвідувачів.
+      </p>
+    </article>
+  </div>
 
   <!-- Structured Data (SEO) -->
   <script type="application/ld+json">

--- a/script.js
+++ b/script.js
@@ -890,6 +890,27 @@ faqLightboxClose?.addEventListener('click', closeFaq);
 faqLightbox?.addEventListener('click', (e) => { if(e.target === faqLightbox) closeFaq(); });
 document.addEventListener('keydown', (e) => { if(e.key === 'Escape' && faqLightbox?.classList.contains('open')) closeFaq(); });
 
+// Privacy modal
+const privacyLink = document.getElementById('privacyLink');
+const privacyLightbox = document.getElementById('privacyLightbox');
+const privacyLightboxClose = document.getElementById('privacyLightboxClose');
+
+function openPrivacy(event){
+  event?.preventDefault();
+  privacyLightbox?.classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+
+function closePrivacy(){
+  privacyLightbox?.classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+privacyLink?.addEventListener('click', openPrivacy);
+privacyLightboxClose?.addEventListener('click', closePrivacy);
+privacyLightbox?.addEventListener('click', (e) => { if(e.target === privacyLightbox) closePrivacy(); });
+document.addEventListener('keydown', (e) => { if(e.key === 'Escape' && privacyLightbox?.classList.contains('open')) closePrivacy(); });
+
 document.querySelectorAll('.faq-item').forEach(item => {
   const btn = item.querySelector('.faq-question');
   const answer = item.querySelector('.faq-answer');

--- a/style.css
+++ b/style.css
@@ -369,6 +369,15 @@ section { padding: 64px 0; }
 .faq-lightbox.open { opacity: 1; pointer-events: auto; }
 .faq-lightbox .close { position: absolute; top: 20px; right: 20px; background: rgba(255,255,255,.8); border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; transition: background 0.2s; }
 .faq-lightbox .close:hover { background: var(--card); }
+.privacy-lightbox { position: fixed; inset: 0; background: rgba(0,0,0,.8); display: flex; align-items: center; justify-content: center; padding: 24px; z-index: 1000; opacity: 0; pointer-events: none; transition: opacity 0.3s ease; }
+.privacy-lightbox.open { opacity: 1; pointer-events: auto; }
+.privacy-lightbox .close { position: absolute; top: 20px; right: 20px; background: rgba(255,255,255,.8); border: none; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; transition: background 0.2s; }
+.privacy-lightbox .close:hover { background: var(--card); }
+.privacy-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 24px; width: 100%; max-width: 640px; max-height: 85vh; overflow-y: auto; scrollbar-gutter: stable; }
+.privacy-card h3 { margin-top: 0; }
+.privacy-card p { margin-bottom: 0; color: var(--text); }
+.privacy-card a { color: var(--brand); text-decoration: underline; }
+.privacy-card a:hover { text-decoration: underline; }
 .faq-card { background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px; width: 100%; max-width: 800px; max-height: 85vh; overflow-y: auto; scrollbar-gutter: stable; }
 .faq-card h3 { margin-top: 0; }
 .faq-item { margin-bottom: 16px; border-bottom: 1px solid #e2ddd5; }
@@ -593,6 +602,14 @@ section { padding: 64px 0; }
 
 /* Footer */
 footer { padding: 40px 0; color: var(--muted); text-align: center; }
+footer .footer-link {
+  margin-left: 12px;
+  color: var(--brand);
+}
+footer .footer-link:hover,
+footer .footer-link:focus {
+  text-decoration: underline;
+}
 
 /* Utilities */
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }

--- a/style.css
+++ b/style.css
@@ -602,8 +602,16 @@ section { padding: 64px 0; }
 
 /* Footer */
 footer { padding: 40px 0; color: var(--muted); text-align: center; }
+footer .footer-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+footer .footer-content p {
+  margin: 0;
+}
 footer .footer-link {
-  margin-left: 12px;
   color: var(--brand);
 }
 footer .footer-link:hover,


### PR DESCRIPTION
## Summary
- add a "Політика приватності" link to the footer that opens a modal
- implement the privacy policy modal with the required Google Analytics disclosure and link
- style the modal and footer link to match the existing lightbox components

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d533b53e40832cb456465b893fdfb0